### PR TITLE
Handle upstreams without a trailing slash

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -43,6 +43,9 @@ func NewOauthProxy(proxyUrls []*url.URL, clientID string, clientSecret string, v
 	serveMux := http.NewServeMux()
 	for _, u := range proxyUrls {
 		path := u.Path
+		if len(path) == 0 {
+			path = "/"
+		}
 		u.Path = ""
 		log.Printf("mapping %s => %s", path, u)
 		serveMux.Handle(path, httputil.NewSingleHostReverseProxy(u))


### PR DESCRIPTION
Currently the proxy does not work when the upstream doesn't contain a trailing slash. This commit should fix this.
