### PR TITLE
Use of secure attribute in cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ Usage of ./google_auth_proxy:
   -client-id="": the Google OAuth Client ID: ie: "123456.apps.googleusercontent.com"
   -client-secret="": the OAuth Client Secret
   -cookie-domain="": an optional cookie domain to force cookies to
+  -cookie-expire=168h: expire timeframe for cookie
+  -cookie-https-only=false: set HTTPS only cookie
   -cookie-secret="": the seed string for secure cookies
-  -google-apps-domain="": authenticate against the given google apps domain
+  -google-apps-domain=[]: authenticate against the given google apps domain (may be given multiple times)
   -htpasswd-file="": additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption
   -http-address="127.0.0.1:4180": <addr>:<port> to listen on for HTTP clients
   -pass-basic-auth=true: pass HTTP Basic Auth information to upstream
@@ -98,6 +100,7 @@ The command line to run `google_auth_proxy` would look like this:
    --google-apps-domain="yourcompany.com"  \
    --upstream=http://127.0.0.1:8080/ \
    --cookie-secret=... \
+   --cookie-secure=true \
    --client-id=... \
    --client-secret=...
 ```
@@ -108,9 +111,9 @@ The environment variables `google_auth_client_id`, `google_auth_secret` and `goo
 
 ## Endpoint Documentation
 
-Google auth proxy responds directly to the following endpoints. All other endpoints will be authenticated.
+Google Auth Proxy responds directly to the following endpoints. All other endpoints will be authenticated.
 
 * /ping - returns an 200 OK response
 * /oauth2/sign_in - the login page, which also doubles as a sign out page (it clears cookies)
-* /oauth2/start - a URL that will redirect to start the oauth cycle
-* /oauth2/callback - the URL used at the end of the oauth cycle
+* /oauth2/start - a URL that will redirect to start the OAuth cycle
+* /oauth2/callback - the URL used at the end of the OAuth cycle

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 const VERSION = "0.1.0"
@@ -23,8 +24,8 @@ var (
 	htpasswdFile            = flag.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
 	cookieSecret            = flag.String("cookie-secret", "", "the seed string for secure cookies")
 	cookieDomain            = flag.String("cookie-domain", "", "an optional cookie domain to force cookies to")
-	cookieExpire            = flag.Int("cookie-expire", 168 * 60, "expire time for cookie")
-	cookieSecure            = flag.Bool("cookie-secure", false, "HTTPS only cookie")
+	cookieExpire            = flag.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
+	cookieHttpsOnly         = flag.Bool("cookie-https-only", false, "set HTTPS only cookie")
 	authenticatedEmailsFile = flag.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
 	googleAppsDomains       = StringArray{}
 	upstreams               = StringArray{}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -184,27 +184,14 @@ func (p *OauthProxy) SetCookie(rw http.ResponseWriter, req *http.Request, val st
 	if *cookieDomain != "" && strings.HasSuffix(domain, *cookieDomain) {
 		domain = *cookieDomain
 	}
-	need_expire := true
-	expire := time.Now().Add(time.Duration(*cookieExpire))
-	if *cookieExpire == 0 {
-		need_expire = false
-	}
-	http_only := true
-	secure := false
-	if *cookieSecure {
-		http_only = false
-		secure = true
-	}
 	cookie := &http.Cookie{
 		Name:     p.CookieKey,
 		Value:    signedCookieValue(p.CookieSeed, p.CookieKey, val),
 		Path:     "/",
 		Domain:   domain,
-		HttpOnly: http_only,
-		Secure:   secure,
-	}
-	if need_expire {
-		cookie.Expires = expire
+		HttpOnly: true,
+		Secure:   *cookieHttpsOnly,
+		Expires:  time.Now().Add(*cookieExpire),
 	}
 	http.SetCookie(rw, cookie)
 }


### PR DESCRIPTION
I see at [Line 191 of oauthproxy.go](https://github.com/bitly/google_auth_proxy/blob/1e29aa1c122fe01bb9436d7ffa6bdd17d5fb8357/oauthproxy.go#L191) the question is raised of whether to use secure cookies if the X-Scheme is https (set the proxy header in nginx).

While this may be a good idea in the long run, in the short term, would it be better to decrease the chance of MITM attacks and set default of secure until a dynamic solution is implemented?

I understand this would cause incompatibility with those using this over HTTP only, though if they are I assume they have a very good reason and would be able to manually build it with the flag not set?

_Would it be better to the increase the default security for the majority of deployments vs. compatibility in certain edge case uses._
