### PR TITLE
When loading client-id/client-secret/cookie-secret from env variables, google_auth_proxy blows up.

### DIFF
--- a/env_options.go
+++ b/env_options.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 )
 
-func LoadOptionsFromEnv(options interface{}, cfg map[string]interface{}) {
+type EnvOptions map[string]interface{}
+
+func (cfg EnvOptions) LoadEnvForStruct(options interface{}) {
 	val := reflect.ValueOf(options).Elem()
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {

--- a/env_options_test.go
+++ b/env_options_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+type envTest struct {
+	testField string `cfg:"target_field" env:"TEST_ENV_FIELD"`
+}
+
+func TestLoadEnvForStruct(t *testing.T) {
+
+	cfg := make(EnvOptions)
+	cfg.LoadEnvForStruct(&envTest{})
+
+	_, ok := cfg["target_field"]
+	assert.Equal(t, ok, false)
+
+	os.Setenv("TEST_ENV_FIELD", "1234abcd")
+	cfg.LoadEnvForStruct(&envTest{})
+	v := cfg["target_field"]
+	assert.Equal(t, v, "1234abcd")
+}

--- a/main.go
+++ b/main.go
@@ -48,14 +48,14 @@ func main() {
 
 	opts := NewOptions()
 
-	var cfg map[string]interface{}
+	cfg := make(EnvOptions)
 	if *config != "" {
 		_, err := toml.DecodeFile(*config, &cfg)
 		if err != nil {
 			log.Fatalf("ERROR: failed to load config file %s - %s", *config, err)
 		}
 	}
-	LoadOptionsFromEnv(opts, cfg)
+	cfg.LoadEnvForStruct(opts)
 	options.Resolve(opts, flagSet, cfg)
 
 	err := opts.Validate()


### PR DESCRIPTION
e.g.

``` shell
export GOOGLE_AUTH_PROXY_COOKIE_SECRET=foo
export GOOGLE_AUTH_PROXY_CLIENT_SECRET=bar
export GOOGLE_AUTH_PROXY_CLIENT_ID=baz

google_auth_proxy -http-address=127.0.0.1:8443 -upstream=http://127.0.0.1:8080/ -redirect-url=https://foo.bar -google-apps-domain=foo.bar
```

errors out as:

```
panic: runtime error: assignment to entry in nil map

goroutine 16 [running]:
runtime.panic(0x74eac0, 0x98be13)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
main.LoadOptionsFromEnv(0x719100, 0xc20808e000, 0x0)
    /root/gopath/src/github.com/bitly/google_auth_proxy/env_options.go:30 +0x3d1
main.main()
    /root/gopath/src/github.com/bitly/google_auth_proxy/main.go:58 +0x9ff
```
