### PR TITLE
Allow hiding custom login UI even if an htpasswd file is provided.

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
+	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
@@ -78,6 +79,7 @@ func main() {
 	if opts.HtpasswdFile != "" {
 		log.Printf("using htpasswd file %s", opts.HtpasswdFile)
 		oauthproxy.HtpasswdFile, err = NewHtpasswdFromFile(opts.HtpasswdFile)
+		oauthproxy.DisplayHtpasswdForm = opts.DisplayHtpasswdForm
 		if err != nil {
 			log.Fatalf("FATAL: unable to open %s %s", opts.HtpasswdFile, err)
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -29,16 +29,17 @@ type OauthProxy struct {
 	CookieExpire    time.Duration
 	Validator       func(string) bool
 
-	redirectUrl        *url.URL // the url to receive requests at
-	oauthRedemptionUrl *url.URL // endpoint to redeem the code
-	oauthLoginUrl      *url.URL // to redirect the user to
-	oauthScope         string
-	clientID           string
-	clientSecret       string
-	SignInMessage      string
-	HtpasswdFile       *HtpasswdFile
-	serveMux           *http.ServeMux
-	PassBasicAuth      bool
+	redirectUrl         *url.URL // the url to receive requests at
+	oauthRedemptionUrl  *url.URL // endpoint to redeem the code
+	oauthLoginUrl       *url.URL // to redirect the user to
+	oauthScope          string
+	clientID            string
+	clientSecret        string
+	SignInMessage       string
+	HtpasswdFile        *HtpasswdFile
+	DisplayHtpasswdForm bool
+	serveMux            *http.ServeMux
+	PassBasicAuth       bool
 }
 
 func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
@@ -112,6 +113,10 @@ func apiRequest(req *http.Request) (*simplejson.Json, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+func (p *OauthProxy) displayCustomLoginForm() bool {
+	return p.HtpasswdFile != nil && p.DisplayHtpasswdForm
 }
 
 func (p *OauthProxy) redeemCode(code string) (string, string, error) {
@@ -232,12 +237,12 @@ func (p *OauthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 
 	t := struct {
 		SignInMessage string
-		Htpasswd      bool
+		CustomLogin   bool
 		Redirect      string
 		Version       string
 	}{
 		SignInMessage: p.SignInMessage,
-		Htpasswd:      p.HtpasswdFile != nil,
+		CustomLogin:   p.displayCustomLoginForm(),
 		Redirect:      req.URL.RequestURI(),
 		Version:       VERSION,
 	}

--- a/options.go
+++ b/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	ClientSecret            string        `flag:"client-secret" cfg:"client_secret" env:"GOOGLE_AUTH_PROXY_CLIENT_SECRET"`
 	PassBasicAuth           bool          `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	HtpasswdFile            string        `flag:"htpasswd-file" cfg:"htpasswd_file"`
+	DisplayHtpasswdForm     bool          `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CookieSecret            string        `flag:"cookie-secret" cfg:"cookie_secret" env:"GOOGLE_AUTH_PROXY_COOKIE_SECRET"`
 	CookieDomain            string        `flag:"cookie-domain" cfg:"cookie_domain" env:"GOOGLE_AUTH_PROXY_COOKIE_DOMAIN"`
 	CookieExpire            time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"GOOGLE_AUTH_PROXY_COOKIE_EXPIRE"`
@@ -30,10 +31,11 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		HttpAddress:     "127.0.0.1:4180",
-		CookieHttpsOnly: true,
-		PassBasicAuth:   true,
-		CookieExpire:    time.Duration(168) * time.Hour,
+		HttpAddress:         "127.0.0.1:4180",
+		DisplayHtpasswdForm: true,
+		CookieHttpsOnly:     true,
+		PassBasicAuth:       true,
+		CookieExpire:        time.Duration(168) * time.Hour,
 	}
 }
 

--- a/templates.go
+++ b/templates.go
@@ -105,8 +105,8 @@ func getTemplates() *template.Template {
 	<button type="submit" class="btn">Sign in with a Google Account</button><br/>
 	</form>
 	</div>
-	
-	{{ if .Htpasswd }}
+
+	{{ if .CustomLogin }}
 	<div class="signin">
 	<form method="POST" action="/oauth2/sign_in">
 		<input type="hidden" name="rd" value="{{.Redirect}}">

--- a/templates_test.go
+++ b/templates_test.go
@@ -8,5 +8,4 @@ import (
 func TestTemplatesCompile(t *testing.T) {
 	templates := getTemplates()
 	assert.NotEqual(t, templates, nil)
-
 }


### PR DESCRIPTION
We have a few apps behind the `google_auth_proxy` that are configured to use an `htpasswd` file for API access. Folks on the team have found the login UI confusing because the `htpasswd` we're providing is only for API access, but providing an `htpasswd` file causes the login UI to display a username / password form along with the "Login with Google" button.

This PR adds a flag called `display-htpasswd-form`. It defaults to `true` so that the current behavior remains the same. If the flag is set to false, the username / password fields on the login page will not be displayed even if an htpasswd file is provided.

Let me know if this is something you're interested in pulling in.
