### PR TITLE
Naming Is Hard - project name change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 google_auth_proxy
+oauth2_proxy
 # Go.gitignore
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-google_auth_proxy
+oaut2_proxy
 =================
 
+(This project was formerly known as Google Auth Proxy)
 
-A reverse proxy that provides authentication using Google and other OAuth2
-providers to validate individual accounts, or a whole google apps domain.
+A reverse proxy that provides authentication using Providers (Google, Github, and others)
+to validate individual accounts, or a whole email domain.
 
-[![Build Status](https://secure.travis-ci.org/bitly/google_auth_proxy.png?branch=master)](http://travis-ci.org/bitly/google_auth_proxy)
+[![Build Status](https://secure.travis-ci.org/bitly/oauth2_proxy.png?branch=master)](http://travis-ci.org/bitly/oauth2_proxy)
 
 
 ![sign_in_page](https://cloud.githubusercontent.com/assets/45028/4970624/7feb7dd8-6886-11e4-93e0-c9904af44ea8.png)
@@ -13,19 +14,19 @@ providers to validate individual accounts, or a whole google apps domain.
 ## Architecture
 
 ```
-    _______       ___________________       __________
-    |Nginx| ----> |google_auth_proxy| ----> |upstream| 
-    -------       -------------------       ----------
-                          ||
-                          \/
-                  [google oauth2 api]
+    _______       ______________       __________
+    |Nginx| ----> |oauth2_proxy| ----> |upstream| 
+    -------       --------------       ----------
+                        ||
+                        \/
+              [provider OAuth2 API]
 ```
 
 
 ## Installation
 
-1. Download [Prebuilt Binary](https://github.com/bitly/google_auth_proxy/releases) or build from `master` with `$ go get github.com/bitly/google_auth_proxy` which should put the binary in `$GOROOT/bin`
-2. Register an OAuth Application with Google
+1. Download [Prebuilt Binary](https://github.com/bitly/oauth2_proxy/releases) or build from `master` with `$ go get github.com/bitly/oauth2_proxy` which should put the binary in `$GOROOT/bin`
+2. Register an OAuth Application with a Provider
 3. Configure Google Auth Proxy using config file, command line options, or environment variables
 4. Deploy behind a SSL endpoint (example provided for Nginx)
 
@@ -33,7 +34,7 @@ providers to validate individual accounts, or a whole google apps domain.
 
 You will need to register an OAuth application with Google (or [another
 provider](#providers)), and configure it with Redirect URI(s) for the domain
-you intend to run `google_auth_proxy` on.
+you intend to run `OAUTH2_PROXY` on.
 
 For Google, the registration steps are:
 
@@ -43,7 +44,7 @@ For Google, the registration steps are:
    * The Application Type should be **Web application**
    * Enter your domain in the Authorized Javascript Origins `https://internal.yourcompany.com`
    * Enter the correct Authorized Redirect URL `https://internal.yourcompany.com/oauth2/callback`
-     * NOTE: `google_auth_proxy` will _only_ callback on the path `/oauth2/callback`
+     * NOTE: `oauth2_proxy` will _only_ callback on the path `/oauth2/callback`
 4. Under "APIs & Auth" choose "Consent Screen"
    * Fill in the necessary fields and Save (this is _required_)
 5. Take note of the **Client ID** and **Client Secret**
@@ -59,19 +60,19 @@ For LinkedIn, the registration steps are:
 
 ## Configuration
 
-`google_auth_proxy` can be configured via [config file](#config-file), [command line options](#command-line-options) or [environment variables](#environment-variables).
+`oauth2_proxy` can be configured via [config file](#config-file), [command line options](#command-line-options) or [environment variables](#environment-variables).
 
 ### Config File
 
-An example [google_auth_proxy.cfg](contrib/google_auth_proxy.cfg.example) config file is in the contrib directory. It can be used by specifying `-config=/etc/google_auth_proxy.cfg`
+An example [OAUTH2_PROXY.cfg](contrib/oauth2_proxy.cfg.example) config file is in the contrib directory. It can be used by specifying `-config=/etc/oauth2_proxy.cfg`
 
 ### Command Line Options
 
 ```
-Usage of google_auth_proxy:
+Usage of oauth2_proxy:
   -authenticated-emails-file="": authenticate against emails via file (one per line)
-  -client-id="": the Google OAuth Client ID: ie: "123456.apps.googleusercontent.com"
-  -client-secret="": the OAuth Client Secret
+  -client-id="": the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
+  -client-secret="": the Client Secret
   -config="": path to config file
   -cookie-domain="": an optional cookie domain to force cookies to (ie: .yourcompany.com)*
   -cookie-expire=168h0m0s: expire timeframe for cookie
@@ -105,12 +106,12 @@ See below for provider specific options
 
 ### Environment variables
 
-The environment variables `GOOGLE_AUTH_PROXY_CLIENT_ID`, `GOOGLE_AUTH_PROXY_CLIENT_SECRET`, `GOOGLE_AUTH_PROXY_COOKIE_SECRET`, `GOOGLE_AUTH_PROXY_COOKIE_DOMAIN` and `GOOGLE_AUTH_PROXY_COOKIE_EXPIRE` can be used in place of the corresponding command-line arguments.
+The environment variables `OAUTH2_PROXY_CLIENT_ID`, `OAUTH2_PROXY_CLIENT_SECRET`, `OAUTH2_PROXY_COOKIE_SECRET`, `OAUTH2_PROXY_COOKIE_DOMAIN` and `OAUTH2_PROXY_COOKIE_EXPIRE` can be used in place of the corresponding command-line arguments.
 
 ### Example Nginx Configuration
 
-This example has a [Nginx](http://nginx.org/) SSL endpoint proxying to `google_auth_proxy` on port `4180`. 
-`google_auth_proxy` then authenticates requests for an upstream application running on port `8080`. The external 
+This example has a [Nginx](http://nginx.org/) SSL endpoint proxying to `oauth2_proxy` on port `4180`. 
+`oauth2_proxy` then authenticates requests for an upstream application running on port `8080`. The external 
 endpoint for this example would be `https://internal.yourcompany.com/`.
 
 An example Nginx config follows. Note the use of `Strict-Transport-Security` header to pin requests to SSL 
@@ -136,10 +137,10 @@ server {
 }
 ```
 
-The command line to run `google_auth_proxy` would look like this:
+The command line to run `oauth2_proxy` would look like this:
 
 ```bash
-./google_auth_proxy \
+./oauth2_proxy \
    --google-apps-domain="yourcompany.com"  \
    --upstream=http://127.0.0.1:8080/ \
    --cookie-secret=... \
@@ -151,7 +152,7 @@ The command line to run `google_auth_proxy` would look like this:
 
 ## Endpoint Documentation
 
-Google Auth Proxy responds directly to the following endpoints. All other endpoints will be proxied upstream when authenticated.
+OAuth2 Proxy responds directly to the following endpoints. All other endpoints will be proxied upstream when authenticated.
 
 * /robots.txt - returns a 200 OK response that disallows all User-agents from all paths; see [robotstxt.org](http://www.robotstxt.org/) for more info
 * /ping - returns an 200 OK response
@@ -161,17 +162,18 @@ Google Auth Proxy responds directly to the following endpoints. All other endpoi
 
 ## Logging Format
 
-Google Auth Proxy logs requests to stdout in a format similar to Apache Combined Log.
+OAuth2 Proxy Proxy logs requests to stdout in a format similar to Apache Combined Log.
 
 ```
 <REMOTE_ADDRESS> - <user@domain.com> [19/Mar/2015:17:20:19 -0400] <HOST_HEADER> GET <UPSTREAM_HOST> "/path/" HTTP/1.1 "<USER_AGENT>" <RESPONSE_CODE> <RESPONSE_BYTES> <REQUEST_DURATION>
 ```
 
-## <a name="providers"></a>Providers other than Google
+## <a name="providers"></a>Providers
 
-Other providers besides Google can be specified by the `providers` flag/config
+Authentication providers can be specified by the `providers` flag/config
 directive. Right now this includes:
 
+* `google` - (default) [Google](https://console.developers.google.com/project)
 * `myusa` - The [MyUSA](https://alpha.my.usa.gov) authentication service
   ([GitHub](https://github.com/18F/myusa))
 * `linkedin` - The [LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) Sign In service.

--- a/dist.sh
+++ b/dist.sh
@@ -20,9 +20,9 @@ echo "... running tests"
 
 for os in linux darwin; do
     echo "... building v$version for $os/$arch"
-    BUILD=$(mktemp -d -t google_auth_proxy)
-    TARGET="google_auth_proxy-$version.$os-$arch.$goversion"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/google_auth_proxy || exit 1
+    BUILD=$(mktemp -d -t oauth2_proxy)
+    TARGET="oauth2_proxy-$version.$os-$arch.$goversion"
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/oauth2_proxy || exit 1
     pushd $BUILD
     tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-	flagSet := flag.NewFlagSet("google_auth_proxy", flag.ExitOnError)
+	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
 	googleAppsDomains := StringArray{}
 	upstreams := StringArray{}
@@ -38,7 +38,7 @@ func main() {
 	flagSet.Var(&googleAppsDomains, "google-apps-domain", "authenticate against the given Google apps domain (may be given multiple times)")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
-	flagSet.String("client-id", "", "the Google OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
+	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
@@ -65,7 +65,7 @@ func main() {
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {
-		fmt.Printf("google_auth_proxy v%s (built with %s)\n", VERSION, runtime.Version())
+		fmt.Printf("oauth2_proxy v%s (built with %s)\n", VERSION, runtime.Version())
 		return
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitly/google_auth_proxy/providers"
+	"github.com/bitly/oauth2_proxy/providers"
 )
 
 const robotsPath = "/robots.txt"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bitly/google_auth_proxy/providers"
+	"github.com/bitly/oauth2_proxy/providers"
 	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"log"

--- a/options.go
+++ b/options.go
@@ -7,15 +7,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitly/google_auth_proxy/providers"
+	"github.com/bitly/oauth2_proxy/providers"
 )
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	RedirectUrl  string `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID     string `flag:"client-id" cfg:"client_id" env:"GOOGLE_AUTH_PROXY_CLIENT_ID"`
-	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"GOOGLE_AUTH_PROXY_CLIENT_SECRET"`
+	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
+	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	GoogleAppsDomains       []string `flag:"google-apps-domain" cfg:"google_apps_domains"`
@@ -25,10 +25,10 @@ type Options struct {
 	DisplayHtpasswdForm     bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CustomTemplatesDir      string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 
-	CookieSecret    string        `flag:"cookie-secret" cfg:"cookie_secret" env:"GOOGLE_AUTH_PROXY_COOKIE_SECRET"`
-	CookieDomain    string        `flag:"cookie-domain" cfg:"cookie_domain" env:"GOOGLE_AUTH_PROXY_COOKIE_DOMAIN"`
-	CookieExpire    time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"GOOGLE_AUTH_PROXY_COOKIE_EXPIRE"`
-	CookieRefresh   time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"GOOGLE_AUTH_PROXY_COOKIE_REFRESH"`
+	CookieSecret    string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
+	CookieDomain    string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
+	CookieExpire    time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
+	CookieRefresh   time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
 	CookieHttpsOnly bool          `flag:"cookie-https-only" cfg:"cookie_https_only"` // deprecated use cookie-secure
 	CookieSecure    bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly  bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -1,7 +1,7 @@
 package providers
 
 import (
-	"github.com/bitly/google_auth_proxy/api"
+	"github.com/bitly/oauth2_proxy/api"
 	"log"
 	"net/http"
 )

--- a/providers/linkedin.go
+++ b/providers/linkedin.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/bitly/google_auth_proxy/api"
+	"github.com/bitly/oauth2_proxy/api"
 )
 
 type LinkedInProvider struct {

--- a/providers/myusa.go
+++ b/providers/myusa.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/bitly/google_auth_proxy/api"
+	"github.com/bitly/oauth2_proxy/api"
 )
 
 type MyUsaProvider struct {

--- a/templates.go
+++ b/templates.go
@@ -130,7 +130,7 @@ func getTemplates() *template.Template {
 	</div>
 	{{ end }}
 	<footer>
-	Secured with <a href="https://github.com/bitly/google_auth_proxy#google_auth_proxy">Google Auth Proxy</a> version {{.Version}}
+	Secured with <a href="https://github.com/bitly/oauth2_proxy#oauth2_proxy">OAuth2 Proxy</a> version {{.Version}}
 	</footer>
 </body>
 </html>


### PR DESCRIPTION
Thanks @balshor @mbland for prompting changes to make the "Google" in "Google Auth Proxy" less relevant. It's high time to rename this project to something more generic.

I've had a few ideas, but i want to open this up to see what ideas anyone else has.

* `GAP` - I'm not sure who started the acronym version of the name but it's stuck. We could just stick with that and remove it's expanded meaning. (if anyone asks we can just say it stood for GreatAuthProxy all along :wink:)
* `AuthProxy` while descriptive, seems too generic
* `OAuthProxy` surprisingly googleable.
* other ideas?
