### PR TITLE
Enabling multiple oauth2_proxy's to exist on the same domain

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
-	flagSet.String("proxy-path", "oauth2", "the url path that this proxy should be nested under")
+	flagSet.String("proxy-prefix", "oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
 
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
+	flagSet.String("proxy-path", "oauth2", "the url path that this proxy should be nested under")
 
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")

--- a/main.go
+++ b/main.go
@@ -44,8 +44,9 @@ func main() {
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
-	flagSet.String("proxy-prefix", "oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
+	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
 
+	flagSet.String("cookie-key", "_oauthproxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
+	ProxyPath    string `flag:"proxy-path" cfg:"proxy-path"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	RedirectUrl  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
@@ -59,6 +60,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
+		ProxyPath:           "oauth2",
 		HttpAddress:         "127.0.0.1:4180",
 		DisplayHtpasswdForm: true,
 		CookieHttpsOnly:     true,

--- a/options.go
+++ b/options.go
@@ -12,7 +12,7 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-	ProxyPath    string `flag:"proxy-path" cfg:"proxy-path"`
+	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	RedirectUrl  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
@@ -60,7 +60,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		ProxyPath:           "oauth2",
+		ProxyPrefix:         "oauth2",
 		HttpAddress:         "127.0.0.1:4180",
 		DisplayHtpasswdForm: true,
 		CookieHttpsOnly:     true,

--- a/options.go
+++ b/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	DisplayHtpasswdForm     bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CustomTemplatesDir      string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 
+	CookieKey       string        `flag:"cookie-key" cfg:"cookie_key"`
 	CookieSecret    string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
 	CookieDomain    string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
 	CookieExpire    time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
@@ -60,9 +61,10 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		ProxyPrefix:         "oauth2",
+		ProxyPrefix:         "/oauth2",
 		HttpAddress:         "127.0.0.1:4180",
 		DisplayHtpasswdForm: true,
+		CookieKey:           "_oauthproxy",
 		CookieHttpsOnly:     true,
 		CookieSecure:        true,
 		CookieHttpOnly:      true,

--- a/templates.go
+++ b/templates.go
@@ -110,7 +110,7 @@ func getTemplates() *template.Template {
 </head>
 <body>
 	<div class="signin center">
-	<form method="GET" action="/{{.ProxyPrefix}}/start">
+	<form method="GET" action="{{.ProxyPrefix}}/start">
 	<input type="hidden" name="rd" value="{{.Redirect}}">
 	{{ if .SignInMessage }}
 	<p>{{.SignInMessage}}</p>
@@ -121,7 +121,7 @@ func getTemplates() *template.Template {
 
 	{{ if .CustomLogin }}
 	<div class="signin">
-	<form method="POST" action="/{{.ProxyPrefix}}/sign_in">
+	<form method="POST" action="{{.ProxyPrefix}}/sign_in">
 		<input type="hidden" name="rd" value="{{.Redirect}}">
 		<label for="username">Username:</label><input type="text" name="username" id="username" size="10"><br/>
 		<label for="password">Password:</label><input type="password" name="password" id="password" size="10"><br/>
@@ -150,7 +150,7 @@ func getTemplates() *template.Template {
 	<h2>{{.Title}}</h2>
 	<p>{{.Message}}</p>
 	<hr>
-	<p><a href="/{{.ProxyPrefix}}/sign_in">Sign In</a></p>
+	<p><a href="{{.ProxyPrefix}}/sign_in">Sign In</a></p>
 </body>
 </html>{{end}}`)
 	if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -110,7 +110,7 @@ func getTemplates() *template.Template {
 </head>
 <body>
 	<div class="signin center">
-	<form method="GET" action="/{{.ProxyPath}}/start">
+	<form method="GET" action="/{{.ProxyPrefix}}/start">
 	<input type="hidden" name="rd" value="{{.Redirect}}">
 	{{ if .SignInMessage }}
 	<p>{{.SignInMessage}}</p>
@@ -121,7 +121,7 @@ func getTemplates() *template.Template {
 
 	{{ if .CustomLogin }}
 	<div class="signin">
-	<form method="POST" action="/{{.ProxyPath}}/sign_in">
+	<form method="POST" action="/{{.ProxyPrefix}}/sign_in">
 		<input type="hidden" name="rd" value="{{.Redirect}}">
 		<label for="username">Username:</label><input type="text" name="username" id="username" size="10"><br/>
 		<label for="password">Password:</label><input type="password" name="password" id="password" size="10"><br/>
@@ -150,7 +150,7 @@ func getTemplates() *template.Template {
 	<h2>{{.Title}}</h2>
 	<p>{{.Message}}</p>
 	<hr>
-	<p><a href="/{{.ProxyPath}}/sign_in">Sign In</a></p>
+	<p><a href="/{{.ProxyPrefix}}/sign_in">Sign In</a></p>
 </body>
 </html>{{end}}`)
 	if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -110,7 +110,7 @@ func getTemplates() *template.Template {
 </head>
 <body>
 	<div class="signin center">
-	<form method="GET" action="/oauth2/start">
+	<form method="GET" action="/{{.ProxyPath}}/start">
 	<input type="hidden" name="rd" value="{{.Redirect}}">
 	{{ if .SignInMessage }}
 	<p>{{.SignInMessage}}</p>
@@ -121,7 +121,7 @@ func getTemplates() *template.Template {
 
 	{{ if .CustomLogin }}
 	<div class="signin">
-	<form method="POST" action="/oauth2/sign_in">
+	<form method="POST" action="/{{.ProxyPath}}/sign_in">
 		<input type="hidden" name="rd" value="{{.Redirect}}">
 		<label for="username">Username:</label><input type="text" name="username" id="username" size="10"><br/>
 		<label for="password">Password:</label><input type="password" name="password" id="password" size="10"><br/>
@@ -150,7 +150,7 @@ func getTemplates() *template.Template {
 	<h2>{{.Title}}</h2>
 	<p>{{.Message}}</p>
 	<hr>
-	<p><a href="/oauth2/sign_in">Sign In</a></p>
+	<p><a href="/{{.ProxyPath}}/sign_in">Sign In</a></p>
 </body>
 </html>{{end}}`)
 	if err != nil {


### PR DESCRIPTION
This PR enables multiple oauth2_proxy's to operate on the same domain while enforcing different levels of security.

The changes required involve namespacing the web template for the specific oauth2_proxy hosting it and namespacing the cookie's key.