### PR TITLE
Fix unsupported WatchForUpdates and build tags

### DIFF
--- a/validator_watcher_copy_test.go
+++ b/validator_watcher_copy_test.go
@@ -1,5 +1,4 @@
-// +build go1.3
-// +build !plan9,!solaris,!windows
+// +build go1.3,!plan9,!solaris,!windows
 
 // Turns out you can't copy over an existing file on Windows.
 

--- a/validator_watcher_test.go
+++ b/validator_watcher_test.go
@@ -1,5 +1,4 @@
-// +build go1.3
-// +build !plan9,!solaris
+// +build go1.3,!plan9,!solaris
 
 package main
 

--- a/watcher.go
+++ b/watcher.go
@@ -1,5 +1,4 @@
-// +build go1.3
-// +build !plan9,!solaris
+// +build go1.3,!plan9,!solaris
 
 package main
 

--- a/watcher_unsupported.go
+++ b/watcher_unsupported.go
@@ -1,5 +1,4 @@
-// +build go1.1
-// +build plan9,solaris
+// +build !go1.3 plan9 solaris
 
 package main
 
@@ -7,7 +6,7 @@ import (
 	"log"
 )
 
-func WatchForUpdates(filename string, action func()) bool {
+func WatchForUpdates(filename string, done <-chan bool, action func()) bool {
 	log.Printf("file watching not implemented on this platform")
 	return false
 }


### PR DESCRIPTION
Closes #105.

The `go1.1` constraint has been updated to `!go1.3` per https://golang.org/pkg/go/build/#hdr-Build_Constraints and https://github.com/go-fsnotify/fsnotify. Also, the existing call signature for `WatchForUpdates()` in `watcher_unsupported.go` was stale.

Perhaps I'll take a stab at installing Plan 9 and Solaris virtual machines over the weekend. :-)

cc: @jehiah @dbiswas1