### PR TITLE
Fix validator_test hang on Solaris, Plan 9

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -21,13 +21,10 @@ func NewUserMap(usersFile string, done <-chan bool, onUpdate func()) *UserMap {
 	atomic.StorePointer(&um.m, unsafe.Pointer(&m))
 	if usersFile != "" {
 		log.Printf("using authenticated emails file %s", usersFile)
-		started := WatchForUpdates(usersFile, done, func() {
+		WatchForUpdates(usersFile, done, func() {
 			um.LoadAuthenticatedEmailsFile()
 			onUpdate()
 		})
-		if started {
-			log.Printf("watching %s for updates", usersFile)
-		}
 		um.LoadAuthenticatedEmailsFile()
 	}
 	return um

--- a/watcher.go
+++ b/watcher.go
@@ -30,7 +30,7 @@ func WaitForReplacement(filename string, op fsnotify.Op,
 	}
 }
 
-func WatchForUpdates(filename string, done <-chan bool, action func()) bool {
+func WatchForUpdates(filename string, done <-chan bool, action func()) {
 	filename = filepath.Clean(filename)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -65,5 +65,5 @@ func WatchForUpdates(filename string, done <-chan bool, action func()) bool {
 	if err = watcher.Add(filename); err != nil {
 		log.Fatal("failed to add ", filename, " to watcher: ", err)
 	}
-	return true
+	log.Printf("watching %s for updates", filename)
 }

--- a/watcher_unsupported.go
+++ b/watcher_unsupported.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-func WatchForUpdates(filename string, done <-chan bool, action func()) bool {
+func WatchForUpdates(filename string, done <-chan bool, action func()) {
 	log.Printf("file watching not implemented on this platform")
-	return false
+	go func() { <-done }()
 }


### PR DESCRIPTION
On these platforms, the `done <- true` statement in during TearDown() was hanging, since the `watcher_unsupported.go` version was never draining the channel. Also took the opportunity to update the WatchForUpdates() signature to not return bool anymore.

I developed this on Solaris 11 running in a VM, and confirmed that it's compatible with OS X. I'll expect it'll work just as well with Linux and Windows, and am trying to figure out how to get Go set up on Plan 9 as we speak.

cc: @jehiah 
