### PR TITLE
disable email validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For Google, the registration steps are:
 1. Create a new project: https://github.com/settings/developers
 2. Under `Authorization callback URL` enter the correct url ie `https://internal.yourcompany.com/oauth2/callback`
 
-The GitHub auth provider supports two additional parameters to restrict authentication to Organization or Team level access.
+The GitHub auth provider supports two additional parameters to restrict authentication to Organization or Team level access. Restricting by org and team is normally accompanied with `--email-domain=*`
 
     -github-org="": restrict logins to members of this organisation
     -github-team="": restrict logins to members of this team
@@ -102,9 +102,9 @@ Usage of oauth2_proxy:
   -cookie-secure=true: set secure (HTTPS) cookie flag
   -custom-templates-dir="": path to custom html templates
   -display-htpasswd-form=true: display username / password login form if an htpasswd file is provided
+  -email-domain=: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
   -github-org="": restrict logins to members of this organisation
   -github-team="": restrict logins to members of this team
-  -google-apps-domain=: authenticate against the given Google apps domain (may be given multiple times)
   -htpasswd-file="": additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption
   -http-address="127.0.0.1:4180": [http://]<addr>:<port> or unix://<path> to listen on for HTTP clients
   -login-url="": Authentication endpoint
@@ -163,7 +163,7 @@ The command line to run `oauth2_proxy` would look like this:
 
 ```bash
 ./oauth2_proxy \
-   --google-apps-domain="yourcompany.com"  \
+   --email-domain="yourcompany.com"  \
    --upstream=http://127.0.0.1:8080/ \
    --cookie-secret=... \
    --cookie-secure=true \

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -22,8 +22,10 @@
 ## when disabled the upstream Host is used as the Host Header
 # pass_host_header = true 
 
-## Email Domains to allow authentication for (this whitelists any email on this domain)
-# google_apps_domains = [
+## Email Domains to allow authentication for (this authorizes any email on this domain)
+## for more granular authorization use `authenticated_emails_file`
+## To authorize any email addresses use "*"
+# email_domains = [
 #     "yourcompany.com"
 # ]
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
-	googleAppsDomains := StringArray{}
+	emailDomains := StringArray{}
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 
@@ -35,7 +35,7 @@ func main() {
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 
-	flagSet.Var(&googleAppsDomains, "google-apps-domain", "authenticate against the given Google apps domain (may be given multiple times)")
+	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
@@ -89,14 +89,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	validator := NewValidator(opts.GoogleAppsDomains, opts.AuthenticatedEmailsFile)
+	validator := NewValidator(opts.EmailDomains, opts.AuthenticatedEmailsFile)
 	oauthproxy := NewOauthProxy(opts, validator)
 
-	if len(opts.GoogleAppsDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
-		if len(opts.GoogleAppsDomains) > 1 {
-			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using one of the following domains: %v", strings.Join(opts.GoogleAppsDomains, ", "))
-		} else {
-			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using %v", opts.GoogleAppsDomains[0])
+	if len(opts.EmailDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
+		if len(opts.EmailDomains) > 1 {
+			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using one of the following domains: %v", strings.Join(opts.EmailDomains, ", "))
+		} else if opts.EmailDomains[0] != "*" {
+			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using %v", opts.EmailDomains[0])
 		}
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -450,7 +450,7 @@ func (p *OauthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			value, err := buildCookieValue(
 				email, p.AesCipher, access_token)
 			if err != nil {
-				log.Printf(err.Error())
+				log.Printf("%s", err)
 			}
 			p.SetCookie(rw, req, value)
 			http.Redirect(rw, req, redirect, 302)

--- a/options.go
+++ b/options.go
@@ -19,7 +19,7 @@ type Options struct {
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
-	GoogleAppsDomains       []string `flag:"google-apps-domain" cfg:"google_apps_domains"`
+	EmailDomains            []string `flag:"email-domain" cfg:"email_domains"`
 	GitHubOrg               string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam              string   `flag:"github-team" cfg:"github_team"`
 	HtpasswdFile            string   `flag:"htpasswd-file" cfg:"htpasswd_file"`

--- a/validator.go
+++ b/validator.go
@@ -62,7 +62,12 @@ func newValidatorImpl(domains []string, usersFile string,
 	done <-chan bool, onUpdate func()) func(string) bool {
 	validUsers := NewUserMap(usersFile, done, onUpdate)
 
+	var allowAll bool
 	for i, domain := range domains {
+		if domain == "*" {
+			allowAll = true
+			continue
+		}
 		domains[i] = fmt.Sprintf("@%s", strings.ToLower(domain))
 	}
 
@@ -74,6 +79,9 @@ func newValidatorImpl(domains []string, usersFile string,
 		}
 		if !valid {
 			valid = validUsers.IsValid(email)
+		}
+		if allowAll {
+			valid = true
 		}
 		log.Printf("validating: is %s valid? %v", email, valid)
 		return valid


### PR DESCRIPTION
Hi, 

I'm using this great tool with an internal OAuth2 provider, in my case I want to authorize access to all authenticated users without any needed validation based on the email address.

Is there currently a way to disable email validation ?

I was thinking to implement pluggable validation system in the same way than the providers, does it sounds good to you ?