### PR TITLE
Native SSL support

### DIFF
--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -1,8 +1,13 @@
 ## OAuth2 Proxy Config File
 ## https://github.com/bitly/oauth2_proxy
 
-## <addr>:<port> to listen on for HTTP clients
+## <addr>:<port> to listen on for HTTP/HTTPS clients
 # http_address = "127.0.0.1:4180"
+# https_address = ":443"
+
+## TLS Settings
+# tls_cert_file = ""
+# tls_key_file = ""
 
 ## the OAuth Redirect URL.
 # defaults to the "https://" + requested host header + "/oauth2/callback"

--- a/http.go
+++ b/http.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Server struct {
+	Handler http.Handler
+	Opts    *Options
+}
+
+func (s *Server) ListenAndServe() {
+	if s.Opts.TLSKeyFile != "" || s.Opts.TLSCertFile != "" {
+		s.ServeHTTPS()
+	} else {
+		s.ServeHTTP()
+	}
+}
+
+func (s *Server) ServeHTTP() {
+	u, err := url.Parse(s.Opts.HttpAddress)
+	if err != nil {
+		log.Fatalf("FATAL: could not parse %#v: %v", s.Opts.HttpAddress, err)
+	}
+
+	var networkType string
+	switch u.Scheme {
+	case "", "http":
+		networkType = "tcp"
+	default:
+		networkType = u.Scheme
+	}
+	listenAddr := strings.TrimPrefix(u.String(), u.Scheme+"://")
+
+	listener, err := net.Listen(networkType, listenAddr)
+	if err != nil {
+		log.Fatalf("FATAL: listen (%s, %s) failed - %s", networkType, listenAddr, err)
+	}
+	log.Printf("HTTP: listening on %s", listenAddr)
+
+	server := &http.Server{Handler: s.Handler}
+	err = server.Serve(listener)
+	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+		log.Printf("ERROR: http.Serve() - %s", err)
+	}
+
+	log.Printf("HTTP: closing %s", listener.Addr())
+}
+
+func (s *Server) ServeHTTPS() {
+	addr := s.Opts.HttpsAddress
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS12,
+	}
+	if config.NextProtos == nil {
+		config.NextProtos = []string{"http/1.1"}
+	}
+
+	var err error
+	config.Certificates = make([]tls.Certificate, 1)
+	config.Certificates[0], err = tls.LoadX509KeyPair(s.Opts.TLSCertFile, s.Opts.TLSKeyFile)
+	if err != nil {
+		log.Fatalf("FATAL: loading tls config (%s, %s) failed - %s", s.Opts.TLSCertFile, s.Opts.TLSKeyFile, err)
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("FATAL: listen (%s) failed - %s", addr, err)
+	}
+	log.Printf("HTTPS: listening on %s", ln.Addr())
+
+	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
+	srv := &http.Server{Handler: s.Handler}
+	err = srv.Serve(tlsListener)
+
+	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+		log.Printf("ERROR: https.Serve() - %s", err)
+	}
+
+	log.Printf("HTTPS: closing %s", tlsListener.Addr())
+}
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -104,7 +104,7 @@ func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 	redirectUrl := opts.redirectUrl
 	redirectUrl.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
 
-	log.Printf("OauthProxy configured for %s", opts.ClientID)
+	log.Printf("OauthProxy configured for %s Client ID: %s", opts.provider.Data().ProviderName, opts.ClientID)
 	domain := opts.CookieDomain
 	if domain == "" {
 		domain = "<default>"
@@ -114,7 +114,7 @@ func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 		opts.CookieSecure = opts.CookieHttpsOnly
 	}
 
-	log.Printf("Cookie settings: secure (https):%v httponly:%v expiry:%s domain:%s", opts.CookieSecure, opts.CookieHttpOnly, opts.CookieExpire, domain)
+	log.Printf("Cookie settings: name:%s secure (https):%v httponly:%v expiry:%s domain:%s", opts.CookieKey, opts.CookieSecure, opts.CookieHttpOnly, opts.CookieExpire, domain)
 
 	var aes_cipher cipher.Block
 	if opts.PassAccessToken || (opts.CookieRefresh != time.Duration(0)) {

--- a/options.go
+++ b/options.go
@@ -14,9 +14,12 @@ import (
 type Options struct {
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
+	HttpsAddress string `flag:"https-address" cfg:"https_address"`
 	RedirectUrl  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
+	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
+	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
 	AuthenticatedEmailsFile string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	EmailDomains            []string `flag:"email-domain" cfg:"email_domains"`
@@ -63,6 +66,7 @@ func NewOptions() *Options {
 	return &Options{
 		ProxyPrefix:         "/oauth2",
 		HttpAddress:         "127.0.0.1:4180",
+		HttpsAddress:        ":443",
 		DisplayHtpasswdForm: true,
 		CookieKey:           "_oauthproxy",
 		CookieHttpsOnly:     true,


### PR DESCRIPTION
Configuration steps would be much simpler if oauth2_proxy supported direct SSL configuration. This would make ssl termination with Nginx the "advanced" configuration.
