### PR TITLE
Cookie Refresh Improvements

### DIFF
--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -54,16 +54,17 @@
 # custom_templates_dir = ""
 
 ## Cookie Settings
-## Name    - the cookie name
-## Secret - the seed string for secure cookies; should be 16, 24, or 32 bytes
-##          for use with an AES cipher when cookie_refresh or pass_access_token
-##          is set
-## Domain - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
-## Expire - (duration) expire timeframe for cookie
-## Refresh - (duration) refresh the cookie when less than this much time remains before
-##           expiration; should be less than cookie_expire; set to 0 to disable.
-##           Refresh revalidated the OAuth token to ensure it is still valid. ie: 24h
-## Secure - secure cookies are only sent by the browser of a HTTPS connection (recommended)
+## Name     - the cookie name
+## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##            for use with an AES cipher when cookie_refresh or pass_access_token
+##            is set
+## Domain   - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
+## Expire   - (duration) expire timeframe for cookie
+## Refresh  - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
+##            Should be less than cookie_expire; set to 0 to disable.
+##            On refresh, OAuth token is re-validated. 
+##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
+## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
 ## HttpOnly - httponly cookies are not readable by javascript (recommended)
 # cookie_name = "_oauth2_proxy"
 # cookie_secret = ""

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -1,23 +1,34 @@
 package providers
 
 import (
-	"github.com/bitly/oauth2_proxy/api"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
+
+	"github.com/bitly/oauth2_proxy/api"
 )
 
 func validateToken(p Provider, access_token string, header http.Header) bool {
 	if access_token == "" || p.Data().ValidateUrl == nil {
 		return false
 	}
-	url := p.Data().ValidateUrl.String()
+	endpoint := p.Data().ValidateUrl.String()
 	if len(header) == 0 {
-		url = url + "?access_token=" + access_token
+		params := url.Values{"access_token": {access_token}}
+		endpoint = endpoint + "?" + params.Encode()
 	}
-	if resp, err := api.RequestUnparsedResponse(url, header); err != nil {
+	resp, err := api.RequestUnparsedResponse(endpoint, header)
+	if err != nil {
 		log.Printf("token validation request failed: %s", err)
 		return false
-	} else {
-		return resp.StatusCode == 200
 	}
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode == 200 {
+		return true
+	}
+	log.Printf("token validation request failed: status %d - %s", resp.StatusCode, body)
+	return false
 }


### PR DESCRIPTION
I experienced a few issues with the current cookie refresh handling, that left me puzzled, but primarily i got a an empty cookie when a refresh should have happened.

This refactors that code a bit to fix that, and switches the timeframe for renewal to be since a cookie was set. (which i think is simpler to understand). Since the requirements (less than expiry) didn't change i think this is ok.

cc: @mbland