### PR TITLE
Check email validity on all requests rather than only on login.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -484,7 +484,7 @@ func (p *OauthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if saveSession && session.Email != "" && !p.Validator(session.Email) {
+	if session != nil && session.Email != "" && !p.Validator(session.Email) {
 		log.Printf("%s Permission Denied: removing session %s", remoteAddr, session)
 		session = nil
 		saveSession = false


### PR DESCRIPTION
I believe this small change handles #125.