### PR TITLE
provider github not work with scope read:org 

### DIFF
--- a/options.go
+++ b/options.go
@@ -103,6 +103,9 @@ func (o *Options) Validate() error {
 	if o.ClientSecret == "" {
 		msgs = append(msgs, "missing setting: client-secret")
 	}
+	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
+		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+	}
 
 	o.redirectUrl, msgs = parseUrl(o.RedirectUrl, "redirect", msgs)
 

--- a/options_test.go
+++ b/options_test.go
@@ -15,6 +15,7 @@ func testOptions() *Options {
 	o.CookieSecret = "foobar"
 	o.ClientID = "bazquux"
 	o.ClientSecret = "xyzzyplugh"
+	o.EmailDomains = []string{"*"}
 	return o
 }
 
@@ -27,6 +28,7 @@ func errorMsg(msgs []string) string {
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
+	o.EmailDomains = []string{"*"}
 	err := o.Validate()
 	assert.NotEqual(t, nil, err)
 

--- a/providers/github.go
+++ b/providers/github.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -211,5 +210,5 @@ func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 		}
 	}
 
-	return "", errors.New("no email address found")
+	return "", nil
 }

--- a/providers/github.go
+++ b/providers/github.go
@@ -66,7 +66,7 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 
 	endpoint := "https://api.github.com/user/orgs?" + params.Encode()
 	req, _ := http.NewRequest("GET", endpoint, nil)
-	req.Header.Set("Accept", "application/vnd.github.moondragon+json")
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false, err
@@ -85,11 +85,16 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 		return false, err
 	}
 
+	var presentOrgs []string
 	for _, org := range orgs {
 		if p.Org == org.Login {
+			log.Printf("Found Github Organization: %q", org.Login)
 			return true, nil
 		}
+		presentOrgs = append(presentOrgs, org.Login)
 	}
+
+	log.Printf("Missing Organization:%q in %v", p.Org, presentOrgs)
 	return false, nil
 }
 
@@ -111,7 +116,7 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 
 	endpoint := "https://api.github.com/user/teams?" + params.Encode()
 	req, _ := http.NewRequest("GET", endpoint, nil)
-	req.Header.Set("Accept", "application/vnd.github.moondragon+json")
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false, err
@@ -130,12 +135,28 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 		return false, fmt.Errorf("%s unmarshaling %s", err, body)
 	}
 
+	var hasOrg bool
+	presentOrgs := make(map[string]bool)
+	var presentTeams []string
 	for _, team := range teams {
+		presentOrgs[team.Org.Login] = true
 		if p.Org == team.Org.Login {
-			if p.Team == "" || p.Team == team.Slug {
+			hasOrg = true
+			if p.Team == team.Slug {
+				log.Printf("Found Github Organization:%q Team:%q (Name:%q)", team.Org.Login, team.Slug, team.Name)
 				return true, nil
 			}
+			presentTeams = append(presentTeams, team.Slug)
 		}
+	}
+	if hasOrg {
+		log.Printf("Missing Team:%q from Org:%q in teams: %v", p.Team, p.Org, presentTeams)
+	} else {
+		var allOrgs []string
+		for org, _ := range presentOrgs {
+			allOrgs = append(allOrgs, org)
+		}
+		log.Printf("Missing Organization:%q in %#v", p.Org, allOrgs)
 	}
 	return false, nil
 }

--- a/providers/linkedin.go
+++ b/providers/linkedin.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -60,13 +59,11 @@ func (p *LinkedInProvider) GetEmailAddress(s *SessionState) (string, error) {
 
 	json, err := api.Request(req)
 	if err != nil {
-		log.Printf("failed making request %s", err)
 		return "", err
 	}
 
 	email, err := json.String()
 	if err != nil {
-		log.Printf("failed making request %s", err)
 		return "", err
 	}
 	return email, nil

--- a/validator.go
+++ b/validator.go
@@ -71,9 +71,11 @@ func newValidatorImpl(domains []string, usersFile string,
 		domains[i] = fmt.Sprintf("@%s", strings.ToLower(domain))
 	}
 
-	validator := func(email string) bool {
+	validator := func(email string) (valid bool) {
+		if email == "" {
+			return
+		}
 		email = strings.ToLower(email)
-		valid := false
 		for _, domain := range domains {
 			valid = valid || strings.HasSuffix(email, domain)
 		}


### PR DESCRIPTION
oauth2_proxy will return 500 to client after got 404 from github api as `error redeeming code got 404 from "https://api.github.com/user/emails?access_token=304d6bd5258b386fef07d9508808f8cd2b795528" {"message":"Not Found","documentation_url":"https://developer.github.com/v3"}` . 

oauth2_proxy request log:
```
2015/07/20 19:01:07 oauthproxy.go:90: mapping path "/" => upstream "http://backend1:16087"
2015/07/20 19:01:07 oauthproxy.go:106: OauthProxy configured for GitHub Client ID: ****
2015/07/20 19:01:07 oauthproxy.go:116: Cookie settings: name:_oauth2_proxy secure(https):false httponly:true expiry:168h0m0s domain:<default> refresh:after 1h0m0s
2015/07/20 19:01:07 http.go:45: HTTP: listening on 127.0.0.1:4180
2015/07/20 19:01:46 oauthproxy.go:455: 127.0.0.1:56904 ("123.116.156.176") Cookie "_oauth2_proxy" not present
123.116.156.176 - - [20/Jul/2015:19:01:46 +0800] mysite.com GET - "/" HTTP/1.0 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12" 403 2244 0.001
123.116.156.176 - - [20/Jul/2015:19:01:49 +0800] mysite.com GET - "/oauth2/start?rd=%2F" HTTP/1.0 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12" 302 248 0.000
2015/07/20 19:01:53 oauthproxy.go:423: 127.0.0.1:56921 ("123.116.156.176") error redeeming code got 404 from "https://api.github.com/user/emails?access_token=304d6bd5258b386fef07d9508808f8cd2b795528" {"message":"Not Found","documentation_url":"https://developer.github.com/v3"}
2015/07/20 19:01:53 oauthproxy.go:270: ErrorPage 500 Internal Error Internal Error
123.116.156.176 - - [20/Jul/2015:19:01:51 +0800] mysite.com GET - "/oauth2/callback?code=92868ca027c52c6fb893&state=%2F" HTTP/1.0 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12" 500 283 1.990
```
oauth2_proxy configs
```
http_address = "127.0.0.1:4180"
redirect_url = "http://mysite.com/oauth2/callback"
upstreams = [     "http://backend1:16087/" ]
request_logging = true

provider = "github"
# not work with redeem-url ="" and false
redeem-url = false
scope = "read:org"
client_id = "***"
client_secret = "***"
-github-org="MyOrg"
-github-team="myteam"

cookie_secret = "Om*****bQA*****wQ"
cookie_refresh = "1h"
cookie_secure = false
```

and oauth2_proxy version
```
./oauth2_proxy --version
oauth2_proxy v2.0.1 (built with go1.4.2)
```

I did not find anything similar in google results or github issues.
Please hint me if there are any mistake in the configs.