### PR TITLE
[RDY] google: Support restricting access to a specific group(s)

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,8 @@
-github.com/BurntSushi/toml              3883ac1ce943878302255f538fce319d23226223
-github.com/bitly/go-simplejson          3378bdcb5cebedcbf8b5750edee28010f128fe24
-github.com/mreiferson/go-options        ee94b57f2fbf116075426f853e5abbcdfeca8b3d
-github.com/bmizerany/assert             e17e99893cb6509f428e1728281c2ad60a6b31e3
-gopkg.in/fsnotify.v1                    v1.2.0
+github.com/BurntSushi/toml               3883ac1ce943878302255f538fce319d23226223
+github.com/bitly/go-simplejson           3378bdcb5cebedcbf8b5750edee28010f128fe24
+github.com/mreiferson/go-options         ee94b57f2fbf116075426f853e5abbcdfeca8b3d
+github.com/bmizerany/assert              e17e99893cb6509f428e1728281c2ad60a6b31e3
+gopkg.in/fsnotify.v1                     v1.2.0
+golang.org/x/oauth2                      397fe7649477ff2e8ced8fc0b2696f781e53745a
+golang.org/x/oauth2/google               397fe7649477ff2e8ced8fc0b2696f781e53745a
+google.golang.org/api/admin/directory/v1 a5c3e2a4792aff40e59840d9ecdff0542a202a80

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 	emailDomains := StringArray{}
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
+	googleGroups := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -39,6 +40,9 @@ func main() {
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
+	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")
+	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
+	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -433,7 +433,7 @@ func (p *OauthProxy) OauthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// set cookie, or deny
-	if p.Validator(session.Email) {
+	if p.Validator(session.Email) && p.provider.ValidateGroup(session.Email) {
 		log.Printf("%s authentication complete %s", remoteAddr, session)
 		err := p.SaveSession(rw, req, session)
 		if err != nil {
@@ -477,7 +477,7 @@ func (p *OauthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		clearSession = true
 	}
 
-	if saveSession && !revalidated && session.AccessToken != "" {
+	if saveSession && !revalidated && session != nil && session.AccessToken != "" {
 		if !p.provider.ValidateSessionState(session) {
 			log.Printf("%s removing session. error validating %s", remoteAddr, session)
 			saveSession = false
@@ -493,7 +493,7 @@ func (p *OauthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		clearSession = true
 	}
 
-	if saveSession {
+	if saveSession && session != nil {
 		err := p.SaveSession(rw, req, session)
 		if err != nil {
 			log.Printf("%s %s", remoteAddr, err)

--- a/options_test.go
+++ b/options_test.go
@@ -40,6 +40,32 @@ func TestNewOptions(t *testing.T) {
 	assert.Equal(t, expected, err.Error())
 }
 
+func TestGoogleGroupOptions(t *testing.T) {
+	o := testOptions()
+	o.GoogleGroups = []string{"googlegroup"}
+	err := o.Validate()
+	assert.NotEqual(t, nil, err)
+
+	expected := errorMsg([]string{
+		"missing setting: google-admin-email",
+		"missing setting: google-service-account-json"})
+	assert.Equal(t, expected, err.Error())
+}
+
+func TestGoogleGroupInvalidFile(t *testing.T) {
+	o := testOptions()
+	o.GoogleGroups = []string{"test_group"}
+	o.GoogleAdminEmail = "admin@example.com"
+	o.GoogleServiceAccountJSON = "file_doesnt_exist.json"
+	err := o.Validate()
+	assert.NotEqual(t, nil, err)
+
+	expected := errorMsg([]string{
+		"invalid Google credentials file: file_doesnt_exist.json",
+	})
+	assert.Equal(t, expected, err.Error())
+}
+
 func TestInitializedOptions(t *testing.T) {
 	o := testOptions()
 	assert.Equal(t, nil, o.Validate())

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -105,6 +105,23 @@ func TestGoogleProviderGetEmailAddress(t *testing.T) {
 	assert.Equal(t, "refresh12345", session.RefreshToken)
 }
 
+func TestGoogleProviderValidateGroup(t *testing.T) {
+	p := newGoogleProvider()
+	p.GroupValidator = func(email string) bool {
+		return email == "michael.bland@gsa.gov"
+	}
+	assert.Equal(t, true, p.ValidateGroup("michael.bland@gsa.gov"))
+	p.GroupValidator = func(email string) bool {
+		return email != "michael.bland@gsa.gov"
+	}
+	assert.Equal(t, false, p.ValidateGroup("michael.bland@gsa.gov"))
+}
+
+func TestGoogleProviderWithoutValidateGroup(t *testing.T) {
+	p := newGoogleProvider()
+	assert.Equal(t, true, p.ValidateGroup("michael.bland@gsa.gov"))
+}
+
 //
 func TestGoogleProviderGetEmailAddressInvalidEncoding(t *testing.T) {
 	p := newGoogleProvider()

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -105,6 +105,12 @@ func (p *ProviderData) GetEmailAddress(s *SessionState) (string, error) {
 	return "", errors.New("not implemented")
 }
 
+// ValidateGroup validates that the provided email exists in the configured provider
+// email group(s).
+func (p *ProviderData) ValidateGroup(email string) bool {
+	return true
+}
+
 func (p *ProviderData) ValidateSessionState(s *SessionState) bool {
 	return validateToken(p, s.AccessToken, nil)
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -8,6 +8,7 @@ type Provider interface {
 	Data() *ProviderData
 	GetEmailAddress(*SessionState) (string, error)
 	Redeem(string, string) (*SessionState, error)
+	ValidateGroup(string) bool
 	ValidateSessionState(*SessionState) bool
 	GetLoginURL(redirectURI, finalRedirect string) string
 	RefreshSessionIfNeeded(*SessionState) (bool, error)


### PR DESCRIPTION
This change should be backwards compatible and only when you pass the three new flags will Google group validation happen.

partially implements features requested in #28 ( getting a list of all groups a user is a member of does not seems to be a single api call and would require listing all groups and then for all groups, querying the group to see if the user is in that group )

potential future improvements (not planned for this PR)
* support orgunits