### PR TITLE
Pass `ProxyPrefix` into the error template.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -287,11 +287,13 @@ func (p *OauthProxy) ErrorPage(rw http.ResponseWriter, code int, title string, m
 	log.Printf("ErrorPage %d %s %s", code, title, message)
 	rw.WriteHeader(code)
 	t := struct {
-		Title   string
-		Message string
+		Title       string
+		Message     string
+		ProxyPrefix string
 	}{
-		Title:   fmt.Sprintf("%d %s", code, title),
-		Message: message,
+		Title:       fmt.Sprintf("%d %s", code, title),
+		Message:     message,
+		ProxyPrefix: p.ProxyPrefix,
 	}
 	p.templates.ExecuteTemplate(rw, "error.html", t)
 }


### PR DESCRIPTION
The default `error.html` uses `ProxyPrefix` but it isn't supplied in the context, causing it to render incompletely:

![image](https://cloud.githubusercontent.com/assets/28967/10265505/2f768960-69e8-11e5-9ac8-303a1580ee53.png)
