### PR TITLE
travis: custom install steps to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: go
 go:
   - 1.3.3
   - 1.4.2
-script:
+  - 1.5.1
+install:
   - curl -s https://raw.githubusercontent.com/pote/gpm/v1.3.2/bin/gpm > gpm
   - chmod +x gpm
+script:
   - ./gpm install
   - ./test.sh
 sudo: false


### PR DESCRIPTION
This adds a workaround for upstream travis Go image changes which added `install: make get-deps` breaking the way this repo expected dependency management.

noticed in #147 by @mbland