### PR TITLE
Don’t log date/time on Heroku.

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,11 @@ import (
 )
 
 func main() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	if os.Getenv("DYNO") != "" {
+		log.SetFlags(log.Lshortfile)
+	} else {
+		log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	}
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
 	emailDomains := StringArray{}


### PR DESCRIPTION
Heroku logging infra already took care of time stamping.

With this commit applied, here's how a typical Heroku log stream looks like:

```
2015-10-12T18:57:07.171422+00:00 app[web.1]: oauthproxy.go:96: mapping path "/" => upstream "http://localhost:7777"
2015-10-12T18:57:07.171427+00:00 app[web.1]: oauthproxy.go:122: OauthProxy configured for Google Client ID: 12345.apps.googleusercontent.com
2015-10-12T18:57:07.171434+00:00 app[web.1]: oauthproxy.go:132: Cookie settings: name:__oa2p secure(https):true httponly:true expiry:168h0m0s domain:<default> refresh:after 1h0m0s
2015-10-12T18:57:07.172172+00:00 app[web.1]: http.go:45: HTTP: listening on 0.0.0.0:29025
```