### PR TITLE
Redirect Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Usage of oauth2_proxy:
   -profile-url="": Profile access endpoint
   -provider="google": OAuth provider
   -proxy-prefix="/oauth2": the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)
+  -redirect-option="/portal": "Redirect to somewhere other than root after authorization (e.g. https://internalapp.yourcompany.com/portal)
   -redeem-url="": Token redemption endpoint
   -redirect-url="": the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
   -request-logging=true: Log requests to stdout

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
-	flagSet.String("redirect-option", "portal", "Redirect to somewhere other than root after authorization (e.g. https://internalapp.yourcompany.com/portal)")
+	flagSet.String("redirect-option", "/portal", "Redirect to somewhere other than root after authorization (e.g. https://internalapp.yourcompany.com/portal)"
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
-
+	flagSet.String("redirect-option", "portal", "Redirect to somewhere other than root after authorization (e.g. https://internalapp.yourcompany.com/portal)")
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")

--- a/options.go
+++ b/options.go
@@ -13,7 +13,8 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
+	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy_prefix"`
+	RedirectOption string `flag:"redirect-option" cfg:"redirect_option"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	HttpsAddress string `flag:"https-address" cfg:"https_address"`
 	RedirectUrl  string `flag:"redirect-url" cfg:"redirect_url"`
@@ -69,6 +70,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
+		RedirectOption:		 "/",
 		ProxyPrefix:         "/oauth2",
 		HttpAddress:         "127.0.0.1:4180",
 		HttpsAddress:        ":443",

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/bitly/oauth2_proxy/cookie"
 )

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -75,7 +75,7 @@ func (p *ProviderData) Redeem(redirectUrl, code string) (s *SessionState, err er
 }
 
 // GetLoginURL with typical oauth parameters
-func (p *ProviderData) GetLoginURL(redirectURI, finalRedirect string) string {
+func (p *ProviderData) GetLoginURL(redirectURI, redirectOption string) string {
 	var a url.URL
 	a = *p.LoginUrl
 	params, _ := url.ParseQuery(a.RawQuery)
@@ -84,9 +84,7 @@ func (p *ProviderData) GetLoginURL(redirectURI, finalRedirect string) string {
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
-	if strings.HasPrefix(finalRedirect, "/") {
-		params.Add("state", finalRedirect)
-	}
+	params.Add("state", redirectOption)
 	a.RawQuery = params.Encode()
 	return a.String()
 }


### PR DESCRIPTION
An option to allow for redirection after authorization to something other than "/".

Potentially breaking change for config files, but needed to be changed to match underscore convention.  ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy_prefix"