### PR TITLE
adding option to skip provider button sign_in page

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
+	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -43,6 +43,7 @@ type OAuthProxy struct {
 	DisplayHtpasswdForm bool
 	serveMux            http.Handler
 	PassBasicAuth       bool
+	SkipProviderButton  bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
 	CookieCipher        *cookie.Cipher
@@ -159,17 +160,18 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		OAuthCallbackPath: fmt.Sprintf("%s/callback", opts.ProxyPrefix),
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 
-		ProxyPrefix:       opts.ProxyPrefix,
-		provider:          opts.provider,
-		serveMux:          serveMux,
-		redirectURL:       redirectURL,
-		skipAuthRegex:     opts.SkipAuthRegex,
-		compiledRegex:     opts.CompiledRegex,
-		PassBasicAuth:     opts.PassBasicAuth,
-		BasicAuthPassword: opts.BasicAuthPassword,
-		PassAccessToken:   opts.PassAccessToken,
-		CookieCipher:      cipher,
-		templates:         loadTemplates(opts.CustomTemplatesDir),
+		ProxyPrefix:        opts.ProxyPrefix,
+		provider:           opts.provider,
+		serveMux:           serveMux,
+		redirectURL:        redirectURL,
+		skipAuthRegex:      opts.SkipAuthRegex,
+		compiledRegex:      opts.CompiledRegex,
+		PassBasicAuth:      opts.PassBasicAuth,
+		BasicAuthPassword:  opts.BasicAuthPassword,
+		PassAccessToken:    opts.PassAccessToken,
+		SkipProviderButton: opts.SkipProviderButton,
+		CookieCipher:       cipher,
+		templates:          loadTemplates(opts.CustomTemplatesDir),
 	}
 }
 
@@ -484,7 +486,11 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		p.ErrorPage(rw, http.StatusInternalServerError,
 			"Internal Error", "Internal Error")
 	} else if status == http.StatusForbidden {
-		p.SignInPage(rw, req, http.StatusForbidden)
+		if p.SkipProviderButton {
+			p.OAuthStart(rw, req)
+		} else {
+			p.SignInPage(rw, req, http.StatusForbidden)
+		}
 	} else {
 		p.serveMux.ServeHTTP(rw, req)
 	}

--- a/options.go
+++ b/options.go
@@ -41,12 +41,13 @@ type Options struct {
 	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
-	Upstreams         []string `flag:"upstream" cfg:"upstreams"`
-	SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
-	PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
-	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
-	PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
-	PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
+	Upstreams          []string `flag:"upstream" cfg:"upstreams"`
+	SkipAuthRegex      []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+	PassBasicAuth      bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+	BasicAuthPassword  string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
+	PassAccessToken    bool     `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassHostHeader     bool     `flag:"pass-host-header" cfg:"pass_host_header"`
+	SkipProviderButton bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -81,6 +82,7 @@ func NewOptions() *Options {
 		PassBasicAuth:       true,
 		PassAccessToken:     false,
 		PassHostHeader:      true,
+		SkipProviderButton:  false,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
 	}


### PR DESCRIPTION
An option to skip the sign_in page and redirect instead to the start page.
That change is for users experience only. My users are fully aware that they will use their google account. They want to avoid any extra steps.