### PR TITLE
Simplify HTTPS listening, leverage net/http methods

### DIFF
--- a/http.go
+++ b/http.go
@@ -59,9 +59,6 @@ func (s *Server) ServeHTTPS() {
 		MinVersion: tls.VersionTLS12,
 		MaxVersion: tls.VersionTLS12,
 	}
-	if config.NextProtos == nil {
-		config.NextProtos = []string{"http/1.1"}
-	}
 
 	var err error
 	config.Certificates = make([]tls.Certificate, 1)
@@ -70,21 +67,12 @@ func (s *Server) ServeHTTPS() {
 		log.Fatalf("FATAL: loading tls config (%s, %s) failed - %s", s.Opts.TLSCertFile, s.Opts.TLSKeyFile, err)
 	}
 
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		log.Fatalf("FATAL: listen (%s) failed - %s", addr, err)
+	srv := &http.Server{
+		Addr:      addr,
+		Handler:   s.Handler,
+		TLSConfig: config,
 	}
-	log.Printf("HTTPS: listening on %s", ln.Addr())
-
-	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
-	srv := &http.Server{Handler: s.Handler}
-	err = srv.Serve(tlsListener)
-
-	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-		log.Printf("ERROR: https.Serve() - %s", err)
-	}
-
-	log.Printf("HTTPS: closing %s", tlsListener.Addr())
+	log.Fatal(srv.ListenAndServeTLS("", ""))
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted


### PR DESCRIPTION
Make use of net/http Server.ListenAndServeTLS — this gives upcoming
http2 support in Go 1.6 for free.