### PR TITLE
Allow options method to bypass authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
+	flagSet.Bool("skip-auth-options", false, "bypass authentication for requests using the https OPTIONS method (useful for CORS requests)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -63,6 +63,7 @@ type OAuthProxy struct {
 	PassAccessToken     bool
 	CookieCipher        *cookie.Cipher
 	skipAuthRegex       []string
+	skipAuthOptions     bool
 	compiledRegex       []*regexp.Regexp
 	templates           *template.Template
 }
@@ -191,6 +192,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		serveMux:          serveMux,
 		redirectURL:       redirectURL,
 		skipAuthRegex:     opts.SkipAuthRegex,
+		skipAuthOptions:   opts.SkipAuthOptions,
 		compiledRegex:     opts.CompiledRegex,
 		PassBasicAuth:     opts.PassBasicAuth,
 		BasicAuthPassword: opts.BasicAuthPassword,
@@ -406,6 +408,10 @@ func getRemoteAddr(req *http.Request) (s string) {
 }
 
 func (p *OAuthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.Method == "OPTIONS" && p.skipAuthOptions {
+		p.serveMux.ServeHTTP(rw, req)
+		return
+	}
 	switch path := req.URL.Path; {
 	case path == p.RobotsPath:
 		p.RobotsTxt(rw)

--- a/options.go
+++ b/options.go
@@ -45,6 +45,7 @@ type Options struct {
 
 	Upstreams         []string `flag:"upstream" cfg:"upstreams"`
 	SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+	SkipAuthOptions   bool     `flag:"skip-auth-options" cfg:"skip_auth_options"`
 	PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`


### PR DESCRIPTION
This allows underlying hosts to set CORS headers as necessary when they receive the OPTIONS request. It seems that the standard when making these preflight CORS requests is to not send authentication data so the oauth cookie is not sent.