### PR TITLE
Ignore spaces in authorized emails list

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -53,7 +53,8 @@ func (um *UserMap) LoadAuthenticatedEmailsFile() {
 	}
 	updated := make(map[string]bool)
 	for _, r := range records {
-		updated[strings.ToLower(r[0])] = true
+		address := strings.ToLower(strings.TrimSpace(r[0]))
+		updated[address] = true
 	}
 	atomic.StorePointer(&um.m, unsafe.Pointer(&updated))
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -147,3 +147,16 @@ func TestValidatorComparisonsAreCaseInsensitive(t *testing.T) {
 		t.Error("validated domains are not lower-cased")
 	}
 }
+
+func TestValidatorIgnoreSpacesInAuthEmails(t *testing.T) {
+	vt := NewValidatorTest(t)
+	defer vt.TearDown()
+
+	vt.WriteEmails(t, []string{"   foo.bar@example.com   "})
+	domains := []string(nil)
+	validator := vt.NewValidator(domains, nil)
+
+	if !validator("foo.bar@example.com") {
+		t.Error("email should validate")
+	}
+}


### PR DESCRIPTION
Got burned by this one: trailing spaces in the authorized e-mail list would cause a mismatch when a user attempted to log in. This PR trims any spaces from the file.