### PR TITLE
Ldap map

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,48 +118,104 @@ An example [oauth2_proxy.cfg](contrib/oauth2_proxy.cfg.example) config file is i
 
 ```
 Usage of oauth2_proxy:
-  -approval-prompt="force": Oauth approval_prompt
-  -authenticated-emails-file="": authenticate against emails via file (one per line)
-  -basic-auth-password="": the password to set when passing the HTTP Basic Auth header
-  -client-id="": the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
-  -client-secret="": the OAuth Client Secret
-  -config="": path to config file
-  -cookie-domain="": an optional cookie domain to force cookies to (ie: .yourcompany.com)*
-  -cookie-expire=168h0m0s: expire timeframe for cookie
-  -cookie-httponly=true: set HttpOnly cookie flag
-  -cookie-name="_oauth2_proxy": the name of the cookie that the oauth_proxy creates
-  -cookie-refresh=0: refresh the cookie after this duration; 0 to disable
-  -cookie-secret="": the seed string for secure cookies
-  -cookie-secure=true: set secure (HTTPS) cookie flag
-  -custom-templates-dir="": path to custom html templates
-  -display-htpasswd-form=true: display username / password login form if an htpasswd file is provided
-  -email-domain=: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
-  -github-org="": restrict logins to members of this organisation
-  -github-team="": restrict logins to members of this team
-  -google-admin-email="": the google admin to impersonate for api calls
-  -google-group=: restrict logins to members of this google group (may be given multiple times).
-  -google-service-account-json="": the path to the service account json credentials
-  -htpasswd-file="": additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption
-  -http-address="127.0.0.1:4180": [http://]<addr>:<port> or unix://<path> to listen on for HTTP clients
-  -https-address=":443": <addr>:<port> to listen on for HTTPS clients
-  -login-url="": Authentication endpoint
-  -pass-access-token=false: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
-  -pass-basic-auth=true: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
-  -pass-host-header=true: pass the request Host Header to upstream
-  -profile-url="": Profile access endpoint
-  -provider="google": OAuth provider
-  -proxy-prefix="/oauth2": the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)
-  -redeem-url="": Token redemption endpoint
-  -redirect-url="": the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
-  -request-logging=true: Log requests to stdout
-  -scope="": Oauth scope specification
-  -signature-key="": GAP-Signature request signature key (algorithm:secretkey)
-  -skip-auth-regex=: bypass authentication for requests path's that match (may be given multiple times)
-  -tls-cert="": path to certificate file
-  -tls-key="": path to private key file
-  -upstream=: the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path
-  -validate-url="": Access token validation endpoint
-  -version=false: print version string
+  -approval-prompt string
+        OAuth approval_prompt (default "force")
+  -authenticated-emails-file string
+        authenticate against emails via file (one per line)
+  -basic-auth-password string
+        the password to set when passing the HTTP Basic Auth header
+  -client-id string
+        the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
+  -client-secret string
+        the OAuth Client Secret
+  -config string
+        path to config file
+  -cookie-domain string
+        an optional cookie domain to force cookies to (ie: .yourcompany.com)*
+  -cookie-expire duration
+        expire timeframe for cookie (default 168h0m0s)
+  -cookie-httponly
+        set HttpOnly cookie flag (default true)
+  -cookie-name string
+        the name of the cookie that the oauth_proxy creates (default "_oauth2_proxy")
+  -cookie-refresh duration
+        refresh the cookie after this duration; 0 to disable
+  -cookie-secret string
+        the seed string for secure cookies
+  -cookie-secure
+        set secure (HTTPS) cookie flag (default true)
+  -custom-templates-dir string
+        path to custom html templates
+  -display-htpasswd-form
+        display username / password login form if an htpasswd file is provided (default true)
+  -email-domain value
+        authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
+  -github-org string
+        restrict logins to members of this organisation
+  -github-team string
+        restrict logins to members of this team
+  -google-admin-email string
+        the google admin to impersonate for api calls
+  -google-group value
+        restrict logins to members of this google group (may be given multiple times).
+  -google-service-account-json string
+        the path to the service account json credentials
+  -htpasswd-file string
+        additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption
+  -http-address string
+        [http://]<addr>:<port> or unix://<path> to listen on for HTTP clients (default "127.0.0.1:4180")
+  -https-address string
+        <addr>:<port> to listen on for HTTPS clients (default ":443")
+  -ldap-bind-pass string
+        Bind user password for LDAP
+  -ldap-bind-user string
+        Bind user for LDAP (ex cn=x,dc=example,dc=com)
+  -ldap-filter-attribute string
+        Attribute used to match Oauth2 email with LDAP. (default "mail")
+  -ldap-mail-attribute string
+        Attribute used to store email in LDAP, this attribute is returned. (default "mail")
+  -ldap-search-base string
+        BaseDN for LDAP search (ex dc=example,dc=com)
+  -ldap-uid-attribute string
+        Attribute used to store uid in LDAP, this attribute is returned. (default "uid")
+  -ldap-uri string
+        URI to LDAP server for mapping email to uid (ex ldap.example.com:389)
+  -login-url string
+        Authentication endpoint
+  -pass-access-token
+        pass OAuth access_token to upstream via X-Forwarded-Access-Token header
+  -pass-basic-auth
+        pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
+  -pass-host-header
+        pass the request Host Header to upstream (default true)
+  -profile-url string
+        Profile access endpoint
+  -provider string
+        OAuth provider (default "google")
+  -proxy-prefix string
+        the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in) (default "/oauth2")
+  -redeem-url string
+        Token redemption endpoint
+  -redirect-url string
+        the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
+  -request-logging
+        Log requests to stdout (default true)
+  -scope string
+        OAuth scope specification
+  -signature-key string
+        GAP-Signature request signature key (algorithm:secretkey)
+  -skip-auth-regex value
+        bypass authentication for requests path's that match (may be given multiple times)
+  -tls-cert string
+        path to certificate file
+  -tls-key string
+        path to private key file
+  -upstream value
+        the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path
+  -validate-url string
+        Access token validation endpoint
+  -version
+        print version string
 ```
 
 See below for provider specific options

--- a/ldap_map.go
+++ b/ldap_map.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/nmcclain/ldap"
+)
+
+// LdapMap provides a means to map email addresses returned from Oauth2 providers to uids provided in Ldap.
+// Ldap must contain an attribute where the email address can be matched for a user. If found, the
+// headers X-Forwarded-User and X-Forwarded-Email will be substituted upstreams.
+func LdapMap(p *OAuthProxy, email string) (string, string, error) {
+	luser := ""
+	lemail := ""
+
+	// Connect to the LDAP server
+	l, err := ldap.Dial("tcp", p.LdapUri)
+	// be sure to add error checking!
+	defer l.Close()
+
+	// Bind using bind user
+	err = l.Bind(p.LdapBindUser, p.LdapBindPass)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Setup filter etc and search
+	filter := fmt.Sprintf("(%s=%s)", p.LdapFilterAttribute, email)
+	attributes := []string{p.LdapUidAttribute, p.LdapMailAttribute}
+	search := ldap.NewSearchRequest(
+		p.LdapSearchBase,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		filter,
+		attributes,
+		nil)
+	searchResults, err := l.Search(search)
+
+	// Handle errors, lack of results etc
+	if err == nil {
+		if len(searchResults.Entries) == 0 {
+			return "", "", errors.New("No matching user found")
+		}
+		luser = searchResults.Entries[0].GetAttributeValue(p.LdapUidAttribute)
+		lemail = searchResults.Entries[0].GetAttributeValue(p.LdapMailAttribute)
+	} else {
+		return "", "", err
+	}
+
+	// Return successful match
+	return luser, lemail, nil
+}

--- a/main.go
+++ b/main.go
@@ -71,6 +71,14 @@ func main() {
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
+	flagSet.String("ldap-uri", "", "URI to LDAP server for mapping email to uid (ex ldap.example.com:389)")
+	flagSet.String("ldap-bind-user", "", "Bind user for LDAP (ex cn=x,dc=example,dc=com)")
+	flagSet.String("ldap-bind-pass", "", "Bind user password for LDAP")
+	flagSet.String("ldap-search-base", "", "BaseDN for LDAP search (ex dc=example,dc=com)")
+	flagSet.String("ldap-filter-attribute", "mail", "Attribute used to match Oauth2 email with LDAP.")
+	flagSet.String("ldap-uid-attribute", "uid", "Attribute used to store uid in LDAP, this attribute is returned.")
+	flagSet.String("ldap-mail-attribute", "mail", "Attribute used to store email in LDAP, this attribute is returned.")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {

--- a/options.go
+++ b/options.go
@@ -1,245 +1,277 @@
 package main
 
 import (
-	"crypto"
-	"fmt"
-	"net/url"
-	"os"
-	"regexp"
-	"strings"
-	"time"
+        "crypto"
+        "fmt"
+        "net/url"
+        "os"
+        "regexp"
+        "strings"
+        "time"
 
-	"github.com/18F/hmacauth"
-	"github.com/bitly/oauth2_proxy/providers"
+        "github.com/18F/hmacauth"
+        "github.com/bitly/oauth2_proxy/providers"
 )
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
-	HttpAddress  string `flag:"http-address" cfg:"http_address"`
-	HttpsAddress string `flag:"https-address" cfg:"https_address"`
-	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
-	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
-	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
-	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
+        ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
+        HttpAddress  string `flag:"http-address" cfg:"http_address"`
+        HttpsAddress string `flag:"https-address" cfg:"https_address"`
+        RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
+        ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
+        ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
+        TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
+        TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
-	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
-	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
-	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
-	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
-	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
-	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
-	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
-	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
-	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
-	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
+        AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
+        EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
+        GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
+        GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
+        GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
+        GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
+        GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+        HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
+        DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
+        CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 
-	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
-	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
-	CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
-	CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
-	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
-	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
-	CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
+        CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
+        CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
+        CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
+        CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
+        CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
+        CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
+        CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
-	Upstreams         []string `flag:"upstream" cfg:"upstreams"`
-	SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
-	PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
-	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
-	PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
-	PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
+        Upstreams         []string `flag:"upstream" cfg:"upstreams"`
+        SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+        PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+        BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
+        PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
+        PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 
-	// These options allow for other providers besides Google, with
-	// potential overrides.
-	Provider       string `flag:"provider" cfg:"provider"`
-	LoginURL       string `flag:"login-url" cfg:"login_url"`
-	RedeemURL      string `flag:"redeem-url" cfg:"redeem_url"`
-	ProfileURL     string `flag:"profile-url" cfg:"profile_url"`
-	ValidateURL    string `flag:"validate-url" cfg:"validate_url"`
-	Scope          string `flag:"scope" cfg:"scope"`
-	ApprovalPrompt string `flag:"approval-prompt" cfg:"approval_prompt"`
+        LdapUri             string `flag:"ldap-uri" cfg:"ldap_uri"`
+        LdapBindUser        string `flag:"ldap-bind-user" cfg:"ldap_bind_user"`
+        LdapBindPass        string `flag:"ldap-bind-pass" cfg:"ldap_bind_pass"`
+        LdapSearchBase      string `flag:"ldap-search-base" cfg:"ldap_search_base"`
+        LdapFilterAttribute string `flag:"ldap-filter-attribute" cfg:"ldap_filter_attribute"`
+        LdapUidAttribute    string `flag:"ldap-uid-attribute" cfg:"ldap_uid_attribute"`
+        LdapMailAttribute   string `flag:"ldap-mail-attribute" cfg:"ldap_mail_attribute"`
 
-	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
+        // These options allow for other providers besides Google, with
+        // potential overrides.
+        Provider       string `flag:"provider" cfg:"provider"`
+        LoginURL       string `flag:"login-url" cfg:"login_url"`
+        RedeemURL      string `flag:"redeem-url" cfg:"redeem_url"`
+        ProfileURL     string `flag:"profile-url" cfg:"profile_url"`
+        ValidateURL    string `flag:"validate-url" cfg:"validate_url"`
+        Scope          string `flag:"scope" cfg:"scope"`
+        ApprovalPrompt string `flag:"approval-prompt" cfg:"approval_prompt"`
 
-	SignatureKey string `flag:"signature-key" cfg:"signature_key"`
+        RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
-	// internal values that are set after config validation
-	redirectURL   *url.URL
-	proxyURLs     []*url.URL
-	CompiledRegex []*regexp.Regexp
-	provider      providers.Provider
-	signatureData *SignatureData
+        SignatureKey string `flag:"signature-key" cfg:"signature_key"`
+
+        // internal values that are set after config validation
+        redirectURL   *url.URL
+        proxyURLs     []*url.URL
+        CompiledRegex []*regexp.Regexp
+        provider      providers.Provider
+        signatureData *SignatureData
 }
 
 type SignatureData struct {
-	hash crypto.Hash
-	key  string
+        hash crypto.Hash
+        key  string
 }
 
 func NewOptions() *Options {
-	return &Options{
-		ProxyPrefix:         "/oauth2",
-		HttpAddress:         "127.0.0.1:4180",
-		HttpsAddress:        ":443",
-		DisplayHtpasswdForm: true,
-		CookieName:          "_oauth2_proxy",
-		CookieSecure:        true,
-		CookieHttpOnly:      true,
-		CookieExpire:        time.Duration(168) * time.Hour,
-		CookieRefresh:       time.Duration(0),
-		PassBasicAuth:       true,
-		PassAccessToken:     false,
-		PassHostHeader:      true,
-		ApprovalPrompt:      "force",
-		RequestLogging:      true,
-	}
+        return &Options{
+                ProxyPrefix:         "/oauth2",
+                HttpAddress:         "127.0.0.1:4180",
+                HttpsAddress:        ":443",
+                DisplayHtpasswdForm: true,
+                CookieName:          "_oauth2_proxy",
+                CookieSecure:        true,
+                CookieHttpOnly:      true,
+                CookieExpire:        time.Duration(168) * time.Hour,
+                CookieRefresh:       time.Duration(0),
+                PassBasicAuth:       true,
+                PassAccessToken:     false,
+                PassHostHeader:      true,
+                ApprovalPrompt:      "force",
+                RequestLogging:      true,
+        }
 }
 
 func parseURL(to_parse string, urltype string, msgs []string) (*url.URL, []string) {
-	parsed, err := url.Parse(to_parse)
-	if err != nil {
-		return nil, append(msgs, fmt.Sprintf(
-			"error parsing %s-url=%q %s", urltype, to_parse, err))
-	}
-	return parsed, msgs
+        parsed, err := url.Parse(to_parse)
+        if err != nil {
+                return nil, append(msgs, fmt.Sprintf(
+                        "error parsing %s-url=%q %s", urltype, to_parse, err))
+        }
+        return parsed, msgs
 }
 
 func (o *Options) Validate() error {
-	msgs := make([]string, 0)
-	if len(o.Upstreams) < 1 {
-		msgs = append(msgs, "missing setting: upstream")
-	}
-	if o.CookieSecret == "" {
-		msgs = append(msgs, "missing setting: cookie-secret")
-	}
-	if o.ClientID == "" {
-		msgs = append(msgs, "missing setting: client-id")
-	}
-	if o.ClientSecret == "" {
-		msgs = append(msgs, "missing setting: client-secret")
-	}
-	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
-		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
-	}
+        msgs := make([]string, 0)
+        if len(o.Upstreams) < 1 {
+                msgs = append(msgs, "missing setting: upstream")
+        }
+        if o.CookieSecret == "" {
+                msgs = append(msgs, "missing setting: cookie-secret")
+        }
+        if o.ClientID == "" {
+                msgs = append(msgs, "missing setting: client-id")
+        }
+        if o.ClientSecret == "" {
+                msgs = append(msgs, "missing setting: client-secret")
+        }
+        if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
+                msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+        }
 
-	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)
+        o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)
 
-	for _, u := range o.Upstreams {
-		upstreamURL, err := url.Parse(u)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf(
-				"error parsing upstream=%q %s",
-				upstreamURL, err))
-		}
-		if upstreamURL.Path == "" {
-			upstreamURL.Path = "/"
-		}
-		o.proxyURLs = append(o.proxyURLs, upstreamURL)
-	}
+        for _, u := range o.Upstreams {
+                upstreamURL, err := url.Parse(u)
+                if err != nil {
+                        msgs = append(msgs, fmt.Sprintf(
+                                "error parsing upstream=%q %s",
+                                upstreamURL, err))
+                }
+                if upstreamURL.Path == "" {
+                        upstreamURL.Path = "/"
+                }
+                o.proxyURLs = append(o.proxyURLs, upstreamURL)
+        }
 
-	for _, u := range o.SkipAuthRegex {
-		CompiledRegex, err := regexp.Compile(u)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf(
-				"error compiling regex=%q %s", u, err))
-		}
-		o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
-	}
-	msgs = parseProviderInfo(o, msgs)
+        for _, u := range o.SkipAuthRegex {
+                CompiledRegex, err := regexp.Compile(u)
+                if err != nil {
+                        msgs = append(msgs, fmt.Sprintf(
+                                "error compiling regex=%q %s", u, err))
+                }
+                o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
+        }
+        msgs = parseProviderInfo(o, msgs)
 
-	if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
-		valid_cookie_secret_size := false
-		for _, i := range []int{16, 24, 32} {
-			if len(o.CookieSecret) == i {
-				valid_cookie_secret_size = true
-			}
-		}
-		if valid_cookie_secret_size == false {
-			msgs = append(msgs, fmt.Sprintf(
-				"cookie_secret must be 16, 24, or 32 bytes "+
-					"to create an AES cipher when "+
-					"pass_access_token == true or "+
-					"cookie_refresh != 0, but is %d bytes",
-				len(o.CookieSecret)))
-		}
-	}
+        if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
+                valid_cookie_secret_size := false
+                for _, i := range []int{16, 24, 32} {
+                        if len(o.CookieSecret) == i {
+                                valid_cookie_secret_size = true
+                        }
+                }
+                if valid_cookie_secret_size == false {
+                        msgs = append(msgs, fmt.Sprintf(
+                                "cookie_secret must be 16, 24, or 32 bytes "+
+                                        "to create an AES cipher when "+
+                                        "pass_access_token == true or "+
+                                        "cookie_refresh != 0, but is %d bytes",
+                                len(o.CookieSecret)))
+                }
+        }
 
-	if o.CookieRefresh >= o.CookieExpire {
-		msgs = append(msgs, fmt.Sprintf(
-			"cookie_refresh (%s) must be less than "+
-				"cookie_expire (%s)",
-			o.CookieRefresh.String(),
-			o.CookieExpire.String()))
-	}
+        if o.CookieRefresh >= o.CookieExpire {
+                msgs = append(msgs, fmt.Sprintf(
+                        "cookie_refresh (%s) must be less than "+
+                                "cookie_expire (%s)",
+                        o.CookieRefresh.String(),
+                        o.CookieExpire.String()))
+        }
 
-	if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
-		if len(o.GoogleGroups) < 1 {
-			msgs = append(msgs, "missing setting: google-group")
-		}
-		if o.GoogleAdminEmail == "" {
-			msgs = append(msgs, "missing setting: google-admin-email")
-		}
-		if o.GoogleServiceAccountJSON == "" {
-			msgs = append(msgs, "missing setting: google-service-account-json")
-		}
-	}
+        if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
+                if len(o.GoogleGroups) < 1 {
+                        msgs = append(msgs, "missing setting: google-group")
+                }
+                if o.GoogleAdminEmail == "" {
+                        msgs = append(msgs, "missing setting: google-admin-email")
+                }
+                if o.GoogleServiceAccountJSON == "" {
+                        msgs = append(msgs, "missing setting: google-service-account-json")
+                }
+        }
 
-	msgs = parseSignatureKey(o, msgs)
+        if len(o.LdapUri) > 0 || len(o.LdapBindUser) > 0 || len(o.LdapBindPass) > 0 || len(o.LdapSearchBase) > 0 || len(o.LdapFilterAttribute) > 0 || len(o.LdapUidAttribute) > 0 || len(o.LdapMailAttribute) > 0 {
+                if len(o.LdapUri) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-uri")
+                }
+                if len(o.LdapBindUser) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-bind-user")
+                }
+                if len(o.LdapBindPass) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-bind-pass")
+                }
+                if len(o.LdapSearchBase) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-search-base")
+                }
+                if len(o.LdapFilterAttribute) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-filter-attribute")
+                }
+                if len(o.LdapUidAttribute) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-uid-attribute")
+                }
+                if len(o.LdapMailAttribute) == 0 {
+                        msgs = append(msgs, "missing setting: ldap-email-attribute")
+                }
+        }
 
-	if len(msgs) != 0 {
-		return fmt.Errorf("Invalid configuration:\n  %s",
-			strings.Join(msgs, "\n  "))
-	}
-	return nil
+        msgs = parseSignatureKey(o, msgs)
+
+        if len(msgs) != 0 {
+                return fmt.Errorf("Invalid configuration:\n  %s",
+                        strings.Join(msgs, "\n  "))
+        }
+        return nil
 }
 
 func parseProviderInfo(o *Options, msgs []string) []string {
-	p := &providers.ProviderData{
-		Scope:          o.Scope,
-		ClientID:       o.ClientID,
-		ClientSecret:   o.ClientSecret,
-		ApprovalPrompt: o.ApprovalPrompt,
-	}
-	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
-	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
-	p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
-	p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
+        p := &providers.ProviderData{
+                Scope:          o.Scope,
+                ClientID:       o.ClientID,
+                ClientSecret:   o.ClientSecret,
+                ApprovalPrompt: o.ApprovalPrompt,
+        }
+        p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
+        p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
+        p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
+        p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
 
-	o.provider = providers.New(o.Provider, p)
-	switch p := o.provider.(type) {
-	case *providers.GitHubProvider:
-		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
-	case *providers.GoogleProvider:
-		if o.GoogleServiceAccountJSON != "" {
-			file, err := os.Open(o.GoogleServiceAccountJSON)
-			if err != nil {
-				msgs = append(msgs, "invalid Google credentials file: "+o.GoogleServiceAccountJSON)
-			} else {
-				p.SetGroupRestriction(o.GoogleGroups, o.GoogleAdminEmail, file)
-			}
-		}
-	}
-	return msgs
+        o.provider = providers.New(o.Provider, p)
+        switch p := o.provider.(type) {
+        case *providers.GitHubProvider:
+                p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
+        case *providers.GoogleProvider:
+                if o.GoogleServiceAccountJSON != "" {
+                        file, err := os.Open(o.GoogleServiceAccountJSON)
+                        if err != nil {
+                                msgs = append(msgs, "invalid Google credentials file: "+o.GoogleServiceAccountJSON)
+                        } else {
+                                p.SetGroupRestriction(o.GoogleGroups, o.GoogleAdminEmail, file)
+                        }
+                }
+        }
+        return msgs
 }
 
 func parseSignatureKey(o *Options, msgs []string) []string {
-	if o.SignatureKey == "" {
-		return msgs
-	}
+        if o.SignatureKey == "" {
+                return msgs
+        }
 
-	components := strings.Split(o.SignatureKey, ":")
-	if len(components) != 2 {
-		return append(msgs, "invalid signature hash:key spec: "+
-			o.SignatureKey)
-	}
+        components := strings.Split(o.SignatureKey, ":")
+        if len(components) != 2 {
+                return append(msgs, "invalid signature hash:key spec: "+
+                        o.SignatureKey)
+        }
 
-	algorithm, secretKey := components[0], components[1]
-	if hash, err := hmacauth.DigestNameToCryptoHash(algorithm); err != nil {
-		return append(msgs, "unsupported signature hash algorithm: "+
-			o.SignatureKey)
-	} else {
-		o.signatureData = &SignatureData{hash, secretKey}
-	}
-	return msgs
+        algorithm, secretKey := components[0], components[1]
+        if hash, err := hmacauth.DigestNameToCryptoHash(algorithm); err != nil {
+                return append(msgs, "unsupported signature hash algorithm: "+
+                        o.SignatureKey)
+        } else {
+                o.signatureData = &SignatureData{hash, secretKey}
+        }
+        return msgs
 }

--- a/options.go
+++ b/options.go
@@ -1,277 +1,277 @@
 package main
 
 import (
-        "crypto"
-        "fmt"
-        "net/url"
-        "os"
-        "regexp"
-        "strings"
-        "time"
+	"crypto"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
 
-        "github.com/18F/hmacauth"
-        "github.com/bitly/oauth2_proxy/providers"
+	"github.com/18F/hmacauth"
+	"github.com/bitly/oauth2_proxy/providers"
 )
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-        ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
-        HttpAddress  string `flag:"http-address" cfg:"http_address"`
-        HttpsAddress string `flag:"https-address" cfg:"https_address"`
-        RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
-        ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
-        ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
-        TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
-        TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
+	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
+	HttpAddress  string `flag:"http-address" cfg:"http_address"`
+	HttpsAddress string `flag:"https-address" cfg:"https_address"`
+	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
+	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
+	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
+	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
+	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
-        AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
-        EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
-        GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
-        GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
-        GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
-        GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
-        GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
-        HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
-        DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
-        CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
+	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
+	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
+	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
+	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
+	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
+	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
+	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
+	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
+	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
+	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 
-        CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
-        CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
-        CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
-        CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
-        CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
-        CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
-        CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
+	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
+	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
+	CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
+	CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
+	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
+	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
+	CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
-        Upstreams         []string `flag:"upstream" cfg:"upstreams"`
-        SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
-        PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
-        BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
-        PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
-        PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
+	Upstreams         []string `flag:"upstream" cfg:"upstreams"`
+	SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+	PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
+	PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 
-        LdapUri             string `flag:"ldap-uri" cfg:"ldap_uri"`
-        LdapBindUser        string `flag:"ldap-bind-user" cfg:"ldap_bind_user"`
-        LdapBindPass        string `flag:"ldap-bind-pass" cfg:"ldap_bind_pass"`
-        LdapSearchBase      string `flag:"ldap-search-base" cfg:"ldap_search_base"`
-        LdapFilterAttribute string `flag:"ldap-filter-attribute" cfg:"ldap_filter_attribute"`
-        LdapUidAttribute    string `flag:"ldap-uid-attribute" cfg:"ldap_uid_attribute"`
-        LdapMailAttribute   string `flag:"ldap-mail-attribute" cfg:"ldap_mail_attribute"`
+	LdapUri             string `flag:"ldap-uri" cfg:"ldap_uri"`
+	LdapBindUser        string `flag:"ldap-bind-user" cfg:"ldap_bind_user"`
+	LdapBindPass        string `flag:"ldap-bind-pass" cfg:"ldap_bind_pass"`
+	LdapSearchBase      string `flag:"ldap-search-base" cfg:"ldap_search_base"`
+	LdapFilterAttribute string `flag:"ldap-filter-attribute" cfg:"ldap_filter_attribute"`
+	LdapUidAttribute    string `flag:"ldap-uid-attribute" cfg:"ldap_uid_attribute"`
+	LdapMailAttribute   string `flag:"ldap-mail-attribute" cfg:"ldap_mail_attribute"`
 
-        // These options allow for other providers besides Google, with
-        // potential overrides.
-        Provider       string `flag:"provider" cfg:"provider"`
-        LoginURL       string `flag:"login-url" cfg:"login_url"`
-        RedeemURL      string `flag:"redeem-url" cfg:"redeem_url"`
-        ProfileURL     string `flag:"profile-url" cfg:"profile_url"`
-        ValidateURL    string `flag:"validate-url" cfg:"validate_url"`
-        Scope          string `flag:"scope" cfg:"scope"`
-        ApprovalPrompt string `flag:"approval-prompt" cfg:"approval_prompt"`
+	// These options allow for other providers besides Google, with
+	// potential overrides.
+	Provider       string `flag:"provider" cfg:"provider"`
+	LoginURL       string `flag:"login-url" cfg:"login_url"`
+	RedeemURL      string `flag:"redeem-url" cfg:"redeem_url"`
+	ProfileURL     string `flag:"profile-url" cfg:"profile_url"`
+	ValidateURL    string `flag:"validate-url" cfg:"validate_url"`
+	Scope          string `flag:"scope" cfg:"scope"`
+	ApprovalPrompt string `flag:"approval-prompt" cfg:"approval_prompt"`
 
-        RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
+	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
-        SignatureKey string `flag:"signature-key" cfg:"signature_key"`
+	SignatureKey string `flag:"signature-key" cfg:"signature_key"`
 
-        // internal values that are set after config validation
-        redirectURL   *url.URL
-        proxyURLs     []*url.URL
-        CompiledRegex []*regexp.Regexp
-        provider      providers.Provider
-        signatureData *SignatureData
+	// internal values that are set after config validation
+	redirectURL   *url.URL
+	proxyURLs     []*url.URL
+	CompiledRegex []*regexp.Regexp
+	provider      providers.Provider
+	signatureData *SignatureData
 }
 
 type SignatureData struct {
-        hash crypto.Hash
-        key  string
+	hash crypto.Hash
+	key  string
 }
 
 func NewOptions() *Options {
-        return &Options{
-                ProxyPrefix:         "/oauth2",
-                HttpAddress:         "127.0.0.1:4180",
-                HttpsAddress:        ":443",
-                DisplayHtpasswdForm: true,
-                CookieName:          "_oauth2_proxy",
-                CookieSecure:        true,
-                CookieHttpOnly:      true,
-                CookieExpire:        time.Duration(168) * time.Hour,
-                CookieRefresh:       time.Duration(0),
-                PassBasicAuth:       true,
-                PassAccessToken:     false,
-                PassHostHeader:      true,
-                ApprovalPrompt:      "force",
-                RequestLogging:      true,
-        }
+	return &Options{
+		ProxyPrefix:         "/oauth2",
+		HttpAddress:         "127.0.0.1:4180",
+		HttpsAddress:        ":443",
+		DisplayHtpasswdForm: true,
+		CookieName:          "_oauth2_proxy",
+		CookieSecure:        true,
+		CookieHttpOnly:      true,
+		CookieExpire:        time.Duration(168) * time.Hour,
+		CookieRefresh:       time.Duration(0),
+		PassBasicAuth:       true,
+		PassAccessToken:     false,
+		PassHostHeader:      true,
+		ApprovalPrompt:      "force",
+		RequestLogging:      true,
+	}
 }
 
 func parseURL(to_parse string, urltype string, msgs []string) (*url.URL, []string) {
-        parsed, err := url.Parse(to_parse)
-        if err != nil {
-                return nil, append(msgs, fmt.Sprintf(
-                        "error parsing %s-url=%q %s", urltype, to_parse, err))
-        }
-        return parsed, msgs
+	parsed, err := url.Parse(to_parse)
+	if err != nil {
+		return nil, append(msgs, fmt.Sprintf(
+			"error parsing %s-url=%q %s", urltype, to_parse, err))
+	}
+	return parsed, msgs
 }
 
 func (o *Options) Validate() error {
-        msgs := make([]string, 0)
-        if len(o.Upstreams) < 1 {
-                msgs = append(msgs, "missing setting: upstream")
-        }
-        if o.CookieSecret == "" {
-                msgs = append(msgs, "missing setting: cookie-secret")
-        }
-        if o.ClientID == "" {
-                msgs = append(msgs, "missing setting: client-id")
-        }
-        if o.ClientSecret == "" {
-                msgs = append(msgs, "missing setting: client-secret")
-        }
-        if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
-                msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
-        }
+	msgs := make([]string, 0)
+	if len(o.Upstreams) < 1 {
+		msgs = append(msgs, "missing setting: upstream")
+	}
+	if o.CookieSecret == "" {
+		msgs = append(msgs, "missing setting: cookie-secret")
+	}
+	if o.ClientID == "" {
+		msgs = append(msgs, "missing setting: client-id")
+	}
+	if o.ClientSecret == "" {
+		msgs = append(msgs, "missing setting: client-secret")
+	}
+	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
+		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+	}
 
-        o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)
+	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)
 
-        for _, u := range o.Upstreams {
-                upstreamURL, err := url.Parse(u)
-                if err != nil {
-                        msgs = append(msgs, fmt.Sprintf(
-                                "error parsing upstream=%q %s",
-                                upstreamURL, err))
-                }
-                if upstreamURL.Path == "" {
-                        upstreamURL.Path = "/"
-                }
-                o.proxyURLs = append(o.proxyURLs, upstreamURL)
-        }
+	for _, u := range o.Upstreams {
+		upstreamURL, err := url.Parse(u)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf(
+				"error parsing upstream=%q %s",
+				upstreamURL, err))
+		}
+		if upstreamURL.Path == "" {
+			upstreamURL.Path = "/"
+		}
+		o.proxyURLs = append(o.proxyURLs, upstreamURL)
+	}
 
-        for _, u := range o.SkipAuthRegex {
-                CompiledRegex, err := regexp.Compile(u)
-                if err != nil {
-                        msgs = append(msgs, fmt.Sprintf(
-                                "error compiling regex=%q %s", u, err))
-                }
-                o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
-        }
-        msgs = parseProviderInfo(o, msgs)
+	for _, u := range o.SkipAuthRegex {
+		CompiledRegex, err := regexp.Compile(u)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf(
+				"error compiling regex=%q %s", u, err))
+		}
+		o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
+	}
+	msgs = parseProviderInfo(o, msgs)
 
-        if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
-                valid_cookie_secret_size := false
-                for _, i := range []int{16, 24, 32} {
-                        if len(o.CookieSecret) == i {
-                                valid_cookie_secret_size = true
-                        }
-                }
-                if valid_cookie_secret_size == false {
-                        msgs = append(msgs, fmt.Sprintf(
-                                "cookie_secret must be 16, 24, or 32 bytes "+
-                                        "to create an AES cipher when "+
-                                        "pass_access_token == true or "+
-                                        "cookie_refresh != 0, but is %d bytes",
-                                len(o.CookieSecret)))
-                }
-        }
+	if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
+		valid_cookie_secret_size := false
+		for _, i := range []int{16, 24, 32} {
+			if len(o.CookieSecret) == i {
+				valid_cookie_secret_size = true
+			}
+		}
+		if valid_cookie_secret_size == false {
+			msgs = append(msgs, fmt.Sprintf(
+				"cookie_secret must be 16, 24, or 32 bytes "+
+					"to create an AES cipher when "+
+					"pass_access_token == true or "+
+					"cookie_refresh != 0, but is %d bytes",
+				len(o.CookieSecret)))
+		}
+	}
 
-        if o.CookieRefresh >= o.CookieExpire {
-                msgs = append(msgs, fmt.Sprintf(
-                        "cookie_refresh (%s) must be less than "+
-                                "cookie_expire (%s)",
-                        o.CookieRefresh.String(),
-                        o.CookieExpire.String()))
-        }
+	if o.CookieRefresh >= o.CookieExpire {
+		msgs = append(msgs, fmt.Sprintf(
+			"cookie_refresh (%s) must be less than "+
+				"cookie_expire (%s)",
+			o.CookieRefresh.String(),
+			o.CookieExpire.String()))
+	}
 
-        if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
-                if len(o.GoogleGroups) < 1 {
-                        msgs = append(msgs, "missing setting: google-group")
-                }
-                if o.GoogleAdminEmail == "" {
-                        msgs = append(msgs, "missing setting: google-admin-email")
-                }
-                if o.GoogleServiceAccountJSON == "" {
-                        msgs = append(msgs, "missing setting: google-service-account-json")
-                }
-        }
+	if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
+		if len(o.GoogleGroups) < 1 {
+			msgs = append(msgs, "missing setting: google-group")
+		}
+		if o.GoogleAdminEmail == "" {
+			msgs = append(msgs, "missing setting: google-admin-email")
+		}
+		if o.GoogleServiceAccountJSON == "" {
+			msgs = append(msgs, "missing setting: google-service-account-json")
+		}
+	}
 
-        if len(o.LdapUri) > 0 || len(o.LdapBindUser) > 0 || len(o.LdapBindPass) > 0 || len(o.LdapSearchBase) > 0 || len(o.LdapFilterAttribute) > 0 || len(o.LdapUidAttribute) > 0 || len(o.LdapMailAttribute) > 0 {
-                if len(o.LdapUri) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-uri")
-                }
-                if len(o.LdapBindUser) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-bind-user")
-                }
-                if len(o.LdapBindPass) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-bind-pass")
-                }
-                if len(o.LdapSearchBase) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-search-base")
-                }
-                if len(o.LdapFilterAttribute) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-filter-attribute")
-                }
-                if len(o.LdapUidAttribute) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-uid-attribute")
-                }
-                if len(o.LdapMailAttribute) == 0 {
-                        msgs = append(msgs, "missing setting: ldap-email-attribute")
-                }
-        }
+	if len(o.LdapUri) > 0 || len(o.LdapBindUser) > 0 || len(o.LdapBindPass) > 0 || len(o.LdapSearchBase) > 0 || len(o.LdapFilterAttribute) > 0 || len(o.LdapUidAttribute) > 0 || len(o.LdapMailAttribute) > 0 {
+		if len(o.LdapUri) == 0 {
+			msgs = append(msgs, "missing setting: ldap-uri")
+		}
+		if len(o.LdapBindUser) == 0 {
+			msgs = append(msgs, "missing setting: ldap-bind-user")
+		}
+		if len(o.LdapBindPass) == 0 {
+			msgs = append(msgs, "missing setting: ldap-bind-pass")
+		}
+		if len(o.LdapSearchBase) == 0 {
+			msgs = append(msgs, "missing setting: ldap-search-base")
+		}
+		if len(o.LdapFilterAttribute) == 0 {
+			msgs = append(msgs, "missing setting: ldap-filter-attribute")
+		}
+		if len(o.LdapUidAttribute) == 0 {
+			msgs = append(msgs, "missing setting: ldap-uid-attribute")
+		}
+		if len(o.LdapMailAttribute) == 0 {
+			msgs = append(msgs, "missing setting: ldap-email-attribute")
+		}
+	}
 
-        msgs = parseSignatureKey(o, msgs)
+	msgs = parseSignatureKey(o, msgs)
 
-        if len(msgs) != 0 {
-                return fmt.Errorf("Invalid configuration:\n  %s",
-                        strings.Join(msgs, "\n  "))
-        }
-        return nil
+	if len(msgs) != 0 {
+		return fmt.Errorf("Invalid configuration:\n  %s",
+			strings.Join(msgs, "\n  "))
+	}
+	return nil
 }
 
 func parseProviderInfo(o *Options, msgs []string) []string {
-        p := &providers.ProviderData{
-                Scope:          o.Scope,
-                ClientID:       o.ClientID,
-                ClientSecret:   o.ClientSecret,
-                ApprovalPrompt: o.ApprovalPrompt,
-        }
-        p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
-        p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
-        p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
-        p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
+	p := &providers.ProviderData{
+		Scope:          o.Scope,
+		ClientID:       o.ClientID,
+		ClientSecret:   o.ClientSecret,
+		ApprovalPrompt: o.ApprovalPrompt,
+	}
+	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
+	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
+	p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
+	p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
 
-        o.provider = providers.New(o.Provider, p)
-        switch p := o.provider.(type) {
-        case *providers.GitHubProvider:
-                p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
-        case *providers.GoogleProvider:
-                if o.GoogleServiceAccountJSON != "" {
-                        file, err := os.Open(o.GoogleServiceAccountJSON)
-                        if err != nil {
-                                msgs = append(msgs, "invalid Google credentials file: "+o.GoogleServiceAccountJSON)
-                        } else {
-                                p.SetGroupRestriction(o.GoogleGroups, o.GoogleAdminEmail, file)
-                        }
-                }
-        }
-        return msgs
+	o.provider = providers.New(o.Provider, p)
+	switch p := o.provider.(type) {
+	case *providers.GitHubProvider:
+		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
+	case *providers.GoogleProvider:
+		if o.GoogleServiceAccountJSON != "" {
+			file, err := os.Open(o.GoogleServiceAccountJSON)
+			if err != nil {
+				msgs = append(msgs, "invalid Google credentials file: "+o.GoogleServiceAccountJSON)
+			} else {
+				p.SetGroupRestriction(o.GoogleGroups, o.GoogleAdminEmail, file)
+			}
+		}
+	}
+	return msgs
 }
 
 func parseSignatureKey(o *Options, msgs []string) []string {
-        if o.SignatureKey == "" {
-                return msgs
-        }
+	if o.SignatureKey == "" {
+		return msgs
+	}
 
-        components := strings.Split(o.SignatureKey, ":")
-        if len(components) != 2 {
-                return append(msgs, "invalid signature hash:key spec: "+
-                        o.SignatureKey)
-        }
+	components := strings.Split(o.SignatureKey, ":")
+	if len(components) != 2 {
+		return append(msgs, "invalid signature hash:key spec: "+
+			o.SignatureKey)
+	}
 
-        algorithm, secretKey := components[0], components[1]
-        if hash, err := hmacauth.DigestNameToCryptoHash(algorithm); err != nil {
-                return append(msgs, "unsupported signature hash algorithm: "+
-                        o.SignatureKey)
-        } else {
-                o.signatureData = &SignatureData{hash, secretKey}
-        }
-        return msgs
+	algorithm, secretKey := components[0], components[1]
+	if hash, err := hmacauth.DigestNameToCryptoHash(algorithm); err != nil {
+		return append(msgs, "unsupported signature hash algorithm: "+
+			o.SignatureKey)
+	} else {
+		o.signatureData = &SignatureData{hash, secretKey}
+	}
+	return msgs
 }


### PR DESCRIPTION
This is the code I mention in Issue 185. I'll restate the purpose below.

We're using Google to do oauth2 SSO to an internal service and Ldap to fetch information about group memberships etc. The problem is that some of our users have different Ldap uids and Google email addresses (without domain part), ex eriste != erik.stenvall.

To solve this I propose to have the oauth2_proxy make an Ldap call, searching for a matching email address and then substitute the values X-Forwarded-User and X-Forwarded-Email with the values retrieved from Ldap.

/Ess