### PR TITLE
use Github provider with GitHub enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ The GitHub auth provider supports two additional parameters to restrict authenti
     -github-org="": restrict logins to members of this organisation
     -github-team="": restrict logins to members of this team
 
+If you are using github enterprise, make sure you set the following to the appropriate url:
+
+    -login-url="<enterprise github url>/login/oauth/authorize"
+    -redeem-url="<enterprise github url>/login/oauth/access_token"
+    -validate-url="<enterprise github api url>/user/emails"
+
 
 ### LinkedIn Auth Provider
 

--- a/providers/github.go
+++ b/providers/github.go
@@ -63,7 +63,7 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 		"limit":        {"100"},
 	}
 
-	endpoint := "https://api.github.com/user/orgs?" + params.Encode()
+	endpoint := p.ValidateURL.Scheme + "://"  + p.ValidateURL.Host + "/user/orgs?" + params.Encode()
 	req, _ := http.NewRequest("GET", endpoint, nil)
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	resp, err := http.DefaultClient.Do(req)
@@ -113,7 +113,7 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 		"limit":        {"100"},
 	}
 
-	endpoint := "https://api.github.com/user/teams?" + params.Encode()
+	endpoint := p.ValidateURL.Scheme + "://" + p.ValidateURL.Host + "/user/teams?" + params.Encode()
 	req, _ := http.NewRequest("GET", endpoint, nil)
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	resp, err := http.DefaultClient.Do(req)
@@ -183,7 +183,7 @@ func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 	params := url.Values{
 		"access_token": {s.AccessToken},
 	}
-	endpoint := "https://api.github.com/user/emails?" + params.Encode()
+	endpoint := p.ValidateURL.Scheme + "://" + p.ValidateURL.Host + p.ValidateURL.Path + "?" + params.Encode()
 	resp, err := http.DefaultClient.Get(endpoint)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Pull request to resolve issue "Custom github url not supported #144"

I removed hard-coded github.com endpoints. With the proposed changes oauth2_proxy works with enterprise github if user sets validateURL (as well as loginURL and redeemURL) to github enterprise endpoint.