### PR TITLE
Add Cloudfoundry provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Usage of oauth2_proxy:
   -login-url="": Authentication endpoint
   -pass-access-token=false: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
   -pass-basic-auth=true: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
+  -pass-user-headers=true: pass X-Forwarded-User and X-Forwarded-Email information to upstream
   -pass-host-header=true: pass the request Host Header to upstream
   -profile-url="": Profile access endpoint
   -provider="google": OAuth provider

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -23,6 +23,7 @@
 
 ## pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
 # pass_basic_auth = true
+# pass_user_headers = true
 ## pass the request Host Header to upstream
 ## when disabled the upstream Host is used as the Host Header
 # pass_host_header = true 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
+	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -59,6 +59,7 @@ type OAuthProxy struct {
 	DisplayHtpasswdForm bool
 	serveMux            http.Handler
 	PassBasicAuth       bool
+	PassUserHeaders     bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
 	CookieCipher        *cookie.Cipher
@@ -193,6 +194,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		skipAuthRegex:     opts.SkipAuthRegex,
 		compiledRegex:     opts.CompiledRegex,
 		PassBasicAuth:     opts.PassBasicAuth,
+		PassUserHeaders:   opts.PassUserHeaders,
 		BasicAuthPassword: opts.BasicAuthPassword,
 		PassAccessToken:   opts.PassAccessToken,
 		CookieCipher:      cipher,
@@ -588,6 +590,12 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	// At this point, the user is authenticated. proxy normally
 	if p.PassBasicAuth {
 		req.SetBasicAuth(session.User, p.BasicAuthPassword)
+		req.Header["X-Forwarded-User"] = []string{session.User}
+		if session.Email != "" {
+			req.Header["X-Forwarded-Email"] = []string{session.Email}
+		}
+	}
+	if p.PassUserHeaders {
 		req.Header["X-Forwarded-User"] = []string{session.User}
 		if session.Email != "" {
 			req.Header["X-Forwarded-Email"] = []string{session.Email}

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -156,6 +156,7 @@ func TestBasicAuthPassword(t *testing.T) {
 	opts.ClientSecret = "foobar"
 	opts.CookieSecure = false
 	opts.PassBasicAuth = true
+	opts.PassUserHeaders = true
 	opts.BasicAuthPassword = "This is a secure password"
 	opts.Validate()
 

--- a/options.go
+++ b/options.go
@@ -47,6 +47,7 @@ type Options struct {
 	Upstreams         []string `flag:"upstream" cfg:"upstreams"`
 	SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
 	PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+	PassUserHeaders   bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
 	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
 	PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
@@ -91,6 +92,7 @@ func NewOptions() *Options {
 		CookieExpire:        time.Duration(168) * time.Hour,
 		CookieRefresh:       time.Duration(0),
 		PassBasicAuth:       true,
+		PassUserHeaders:     true,
 		PassAccessToken:     false,
 		PassHostHeader:      true,
 		ApprovalPrompt:      "force",

--- a/providers/cloudfoundry.go
+++ b/providers/cloudfoundry.go
@@ -1,0 +1,77 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+type CloudFoundryProvider struct {
+	*ProviderData
+}
+
+func NewCloudFoundryProvider(p *ProviderData) *CloudFoundryProvider {
+	p.ProviderName = "CloudFoundry"
+	// Defaults for Bosh-Lite, must be configured for other OAuth Endpoints.
+	if p.LoginURL == nil || p.LoginURL.String() == "" {
+		p.LoginURL = &url.URL{
+                        Scheme: "http",
+                        Host:   "login.bosh-lite.com",
+                        Path:   "/oauth/authorize",
+                }
+	}
+	if p.RedeemURL == nil || p.RedeemURL.String() == "" {
+		p.RedeemURL = &url.URL{
+                        Scheme: "http",
+                        Host:   "login.bosh-lite.com",
+                        Path:   "/oauth/token",
+                }
+	}
+	if p.ValidateURL == nil || p.ValidateURL.String() == "" {
+		p.ValidateURL = &url.URL{
+                        Scheme: "http",
+                        Host:   "login.bosh-lite.com",
+                        Path:   "/userinfo",
+                }
+	}
+	if p.Scope == "" {
+		p.Scope = "openid"
+	}
+	return &CloudFoundryProvider{ProviderData: p}
+}
+
+func (p *CloudFoundryProvider) GetEmailAddress(s *SessionState) (string, error) {
+
+	var email struct {
+		Email   string `json:"email"`
+	}
+
+	params := url.Values{
+		"access_token": {s.AccessToken},
+	}
+	endpoint := p.ValidateURL.String() + "?" + params.Encode()
+	resp, err := http.DefaultClient.Get(endpoint)
+	if err != nil {
+		return "", err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("got %d from %q %s", resp.StatusCode, endpoint, body)
+	} else {
+		log.Printf("got %d from %q %s", resp.StatusCode, endpoint, body)
+	}
+
+	if err := json.Unmarshal(body, &email); err != nil {
+		return "", fmt.Errorf("%s unmarshaling %s", err, body)
+	}
+
+	return email.Email, nil
+}

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -35,6 +35,10 @@ func (p *ProviderData) Redeem(redirectURL, code string) (s *SessionState, err er
 		return
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// workaround for Cloudfoundry UAA bug https://github.com/cloudfoundry/uaa/issues/308
+	if (p.ProviderName == "CloudFoundry") {
+		req.SetBasicAuth(p.ClientID, p.ClientSecret)
+	}
 
 	var resp *http.Response
 	resp, err = http.DefaultClient.Do(req)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -26,6 +26,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewGitHubProvider(p)
 	case "azure":
 		return NewAzureProvider(p)
+	case "cloudfoundry":
+		return NewCloudFoundryProvider(p)
 	default:
 		return NewGoogleProvider(p)
 	}


### PR DESCRIPTION
this adds a provider for Cloudfoundry's UAA [1]

if you think this makes sense we can also add some unit tests.

The second commit allows to set X-Forwarded-User independent of HTTP Basic Auth as we need this for our Cloudfoundry/grafana scenario [2]

[1] https://github.com/cloudfoundry/uaa
[2] http://docs.grafana.org/installation/configuration/#authproxy
