### PR TITLE
OAUTH2_PROXY_SIGNATURE_KEY env var, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,16 @@ Multiple upstreams can either be configured by supplying a comma separated list 
 
 ### Environment variables
 
-The environment variables `OAUTH2_PROXY_CLIENT_ID`, `OAUTH2_PROXY_CLIENT_SECRET`, `OAUTH2_PROXY_COOKIE_SECRET`, `OAUTH2_PROXY_COOKIE_DOMAIN` and `OAUTH2_PROXY_COOKIE_EXPIRE` can be used in place of the corresponding command-line arguments.
+The following environment variables can be used in place of the corresponding command-line arguments:
+
+- `OAUTH2_PROXY_CLIENT_ID`
+- `OAUTH2_PROXY_CLIENT_SECRET`
+- `OAUTH2_PROXY_COOKIE_NAME`
+- `OAUTH2_PROXY_COOKIE_SECRET`
+- `OAUTH2_PROXY_COOKIE_DOMAIN`
+- `OAUTH2_PROXY_COOKIE_EXPIRE`
+- `OAUTH2_PROXY_COOKIE_REFRESH`
+- `OAUTH2_PROXY_SIGNATURE_KEY`
 
 ## SSL Configuration
 

--- a/options.go
+++ b/options.go
@@ -64,7 +64,7 @@ type Options struct {
 
 	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
-	SignatureKey string `flag:"signature-key" cfg:"signature_key"`
+	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
 	// internal values that are set after config validation
 	redirectURL   *url.URL


### PR DESCRIPTION
Should've been part of #147. Motivated to add it by the Dockerization I'm performing in [18F/knowledge-sharing-toolkit](https://github.com/18F/knowledge-sharing-toolkit/).

cc: @jehiah @jcscottiii @mzia @NoahKunin @afeld @jmcarp @ccostino @ertzeid @mtorres253