### PR TITLE
Allow setting github provider /user/orgs endpoint url

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
+	flagSet.String("github-validate-org-url", "", "Github token org info url")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")

--- a/options.go
+++ b/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
+	GitHubValidateOrgURL     string   `flag:"github-validate-org-url" cfg:"github_validate_org_url"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
@@ -214,6 +215,9 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	case *providers.AzureProvider:
 		p.Configure(o.AzureTenant)
 	case *providers.GitHubProvider:
+		var validateOrgUrl *url.URL
+		validateOrgUrl, msgs = parseURL(o.GitHubValidateOrgURL, "validate-org", msgs)
+		p.SetValidateOrgURL(validateOrgUrl)
 		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {

--- a/providers/github.go
+++ b/providers/github.go
@@ -14,6 +14,7 @@ type GitHubProvider struct {
 	*ProviderData
 	Org  string
 	Team string
+	ValidateOrgURL *url.URL
 }
 
 func NewGitHubProvider(p *ProviderData) *GitHubProvider {
@@ -42,8 +43,18 @@ func NewGitHubProvider(p *ProviderData) *GitHubProvider {
 	if p.Scope == "" {
 		p.Scope = "user:email"
 	}
-	return &GitHubProvider{ProviderData: p}
+	gp := &GitHubProvider{ProviderData: p}
+	gp.ValidateOrgURL = &url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   "/user/orgs",
+	}
+	return gp
 }
+func (p *GitHubProvider) SetValidateOrgURL(url *url.URL) {
+	p.ValidateOrgURL = url
+}
+
 func (p *GitHubProvider) SetOrgTeam(org, team string) {
 	p.Org = org
 	p.Team = team
@@ -64,7 +75,7 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 		"limit":        {"100"},
 	}
 
-	endpoint := p.ValidateURL.Scheme + "://"  + p.ValidateURL.Host + "/user/orgs?" + params.Encode()
+	endpoint := p.ValidateOrgURL.Scheme + "://"  + p.ValidateOrgURL.Host + p.ValidateOrgURL.Path + "?" + params.Encode()
 	req, _ := http.NewRequest("GET", endpoint, nil)
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
This is a bit of a hack, but it does allow enterprise github setups to limit to orgs.  Open to recommendation how to do this nicer...