### PR TITLE
Use X-Original-URI for redirect if used in as 401 error_page

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -387,6 +387,9 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (string, error) {
 	}
 
 	redirect := req.FormValue("rd")
+	if req.Header.Get("X-Original-URI") != "" {
+		redirect = req.Header.Get("X-Original-URI")
+	}
 
 	if redirect == "" {
 		redirect = "/"

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -332,6 +332,9 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	rw.WriteHeader(code)
 
 	redirect_url := req.URL.RequestURI()
+	if req.Header.Get("X-Original-URI") != "" {
+		redirect_url = req.Header.Get("X-Original-URI")
+	}
 	if redirect_url == p.SignInPath {
 		redirect_url = "/"
 	}


### PR DESCRIPTION
Otherwise it always redirects to /oauth2