### PR TITLE
fix master build by upgrading with supported golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.3.3
-  - 1.4.2
+  - 1.5.4
+  - 1.6.2
 script:
   - curl -s https://raw.githubusercontent.com/pote/gpm/v1.3.2/bin/gpm > gpm
   - chmod +x gpm


### PR DESCRIPTION
was able to reproduce this locally, but not with 1.5.4 and 1.6.2.

This has affected builds since https://github.com/bitly/oauth2_proxy/pull/247, although I found out because my local build (on 1.6.2) worked before I pushed https://github.com/bitly/oauth2_proxy/pull/248