### PR TITLE
Remove superfluous quotes from config path

### DIFF
--- a/contrib/oauth2_proxy.service.example
+++ b/contrib/oauth2_proxy.service.example
@@ -12,7 +12,7 @@ After=syslog.target network.target
 User=www-data
 Group=www-data
 
-ExecStart=/usr/local/bin/oauth2_proxy -config="/etc/oauth2_proxy.cfg"
+ExecStart=/usr/local/bin/oauth2_proxy -config=/etc/oauth2_proxy.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 
 KillMode=process


### PR DESCRIPTION
Using -config="path" will make the application try to open paths with the quotes included which is not what is expected.

```
main.go:89: ERROR: failed to load config file "/etc/oauth2_proxy.cfg" - open "/etc/oauth2_proxy.cfg": no such file or directory
```