### PR TITLE
Add option to set custom footer text

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
+	flagSet.String("footer", "", "custom footer string")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
 
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -65,6 +65,8 @@ type OAuthProxy struct {
 	skipAuthRegex       []string
 	compiledRegex       []*regexp.Regexp
 	templates           *template.Template
+
+	Footer string
 }
 
 type UpstreamProxy struct {
@@ -197,6 +199,8 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		PassAccessToken:   opts.PassAccessToken,
 		CookieCipher:      cipher,
 		templates:         loadTemplates(opts.CustomTemplatesDir),
+
+		Footer: opts.Footer,
 	}
 }
 
@@ -343,6 +347,7 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 		Redirect      string
 		Version       string
 		ProxyPrefix   string
+		Footer        string
 	}{
 		ProviderName:  p.provider.Data().ProviderName,
 		SignInMessage: p.SignInMessage,
@@ -350,6 +355,7 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 		Redirect:      redirect_url,
 		Version:       VERSION,
 		ProxyPrefix:   p.ProxyPrefix,
+		Footer:        p.Footer,
 	}
 	p.templates.ExecuteTemplate(rw, "sign_in.html", t)
 }

--- a/options.go
+++ b/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file"`
 	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
+	Footer                   string   `flag:"footer" cfg:"footer"`
 
 	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
 	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`

--- a/templates.go
+++ b/templates.go
@@ -130,7 +130,11 @@ func getTemplates() *template.Template {
 	</div>
 	{{ end }}
 	<footer>
+	{{ if eq .Footer "" }}
 	Secured with <a href="https://github.com/bitly/oauth2_proxy#oauth2_proxy">OAuth2 Proxy</a> version {{.Version}}
+	{{ else }}
+	{{.Footer}}
+	{{ end }}
 	</footer>
 </body>
 </html>


### PR DESCRIPTION
Intended to resolve #166.  Adds an option (in all the usual spots) called "footer" that allows for overriding the existing footer text.  It's a static value.  If you want the footer to go away altogether, just set it to " " (single space, not empty string).  If it's set to empty string (default), it'll do the usual version/link footer.  I expect that it's simple plaintext and any HTML would be escaped by the template.