### PR TITLE
fix dist.sh compatibility with GNU coreutils mktemp

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -20,7 +20,7 @@ echo "... running tests"
 
 for os in windows linux darwin; do
     echo "... building v$version for $os/$arch"
-    BUILD=$(mktemp -d -t oauth2_proxy)
+    BUILD=$(mktemp -d ${TMPDIR:-/tmp}/oauth2_proxy.XXXXXX)
     TARGET="oauth2_proxy-$version.$os-$arch.$goversion"
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/oauth2_proxy || exit 1
     pushd $BUILD


### PR DESCRIPTION
Resolves this error:

    mktemp: too few X's in template ‘oauth2_proxy’