### PR TITLE
avoid accidentally-base64 cookie secrets being treated as base64

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -427,7 +427,7 @@ func NewProcessCookieTest(opts ProcessCookieTestOpts) *ProcessCookieTest {
 	pc_test.opts = NewOptions()
 	pc_test.opts.ClientID = "bazquux"
 	pc_test.opts.ClientSecret = "xyzzyplugh"
-	pc_test.opts.CookieSecret = "0123456789abcdefabcd"
+	pc_test.opts.CookieSecret = "0!23456789@bcdef"
 	// First, set the CookieRefresh option so proxy.AesCipher is created,
 	// needed to encrypt the access_token.
 	pc_test.opts.CookieRefresh = time.Hour

--- a/options.go
+++ b/options.go
@@ -264,8 +264,6 @@ func parseSignatureKey(o *Options, msgs []string) []string {
 func addPadding(secret string) string {
 	padding := len(secret) % 4
 	switch padding {
-	case 1:
-		return secret + "==="
 	case 2:
 		return secret + "=="
 	case 3:
@@ -278,8 +276,8 @@ func addPadding(secret string) string {
 // secretBytes attempts to base64 decode the secret, if that fails it treats the secret as binary
 func secretBytes(secret string) []byte {
 	b, err := base64.URLEncoding.DecodeString(addPadding(secret))
-	if err == nil {
-		return []byte(addPadding(string(b)))
+	if err == nil && (len(b) == 16 || len(b) == 24 || len(b) == 32)  {
+		return b
 	}
 	return []byte(secret)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -160,7 +160,7 @@ func TestCookieRefreshMustBeLessThanCookieExpire(t *testing.T) {
 	o := testOptions()
 	assert.Equal(t, nil, o.Validate())
 
-	o.CookieSecret = "0123456789abcdefabcd"
+	o.CookieSecret = "0123456789abcdefabcdef=="
 	o.CookieRefresh = o.CookieExpire
 	assert.NotEqual(t, nil, o.Validate())
 


### PR DESCRIPTION
don't pad result of base64 decoding, this makes some secret strings valid if considered base64, when they shouldn't be

check length of base64 decoding, don't treat as base64 if not valid secret length

No base64 string will have/need '===' padding.

Fix two tests that were interpreted as base64, but only described 15 bytes if so interpreted
- make one 16 chars (not base64)
- make one base64 of 16 bytes (needs 2 more non-pad chars) (and optional pad)
