### PR TITLE
add support for basic auth user instead of oauthed user with basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Usage of oauth2_proxy:
   -approval-prompt="force": Oauth approval_prompt
   -authenticated-emails-file="": authenticate against emails via file (one per line)
   -azure-tenant="common": go to a tenant-specific or common (tenant-independent) endpoint.
+  -basic-auth-user="": the username to set when passing the HTTP Basic Auth header
   -basic-auth-password="": the password to set when passing the HTTP Basic Auth header
   -client-id="": the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
   -client-secret="": the OAuth Client Secret

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
+	flagSet.String("basic-auth-user", "", "the username to set when passing the HTTP Basic Auth header")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -60,6 +60,7 @@ type OAuthProxy struct {
 	serveMux            http.Handler
 	PassBasicAuth       bool
 	SkipProviderButton  bool
+	BasicAuthUser       string
 	BasicAuthPassword   string
 	PassAccessToken     bool
 	CookieCipher        *cookie.Cipher
@@ -194,6 +195,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		skipAuthRegex:      opts.SkipAuthRegex,
 		compiledRegex:      opts.CompiledRegex,
 		PassBasicAuth:      opts.PassBasicAuth,
+		BasicAuthUser:      opts.BasicAuthUser,
 		BasicAuthPassword:  opts.BasicAuthPassword,
 		PassAccessToken:    opts.PassAccessToken,
 		SkipProviderButton: opts.SkipProviderButton,
@@ -596,7 +598,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 
 	// At this point, the user is authenticated. proxy normally
 	if p.PassBasicAuth {
-		req.SetBasicAuth(session.User, p.BasicAuthPassword)
+		req.SetBasicAuth(p.BasicAuthUser, p.BasicAuthPassword)
 		req.Header["X-Forwarded-User"] = []string{session.User}
 		if session.Email != "" {
 			req.Header["X-Forwarded-Email"] = []string{session.Email}

--- a/options.go
+++ b/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	Upstreams          []string `flag:"upstream" cfg:"upstreams"`
 	SkipAuthRegex      []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
 	PassBasicAuth      bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+	BasicAuthUser      string   `flag:"basic-auth-user" cfg:"basic_auth_user"`
 	BasicAuthPassword  string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken    bool     `flag:"pass-access-token" cfg:"pass_access_token"`
 	PassHostHeader     bool     `flag:"pass-host-header" cfg:"pass_host_header"`


### PR DESCRIPTION
I was surprised to find out that when authenticating to an upstream there were only the following supported configurations:
a) pass X-Forwarded-User and X-Forwarded-Email
b) pass X-Forwarded-User and X-Forwarded-Email with a configured basic auth password (-basic-auth-password)
c) pass nothing

A common usecase I've run into is passing full basic auth to an upstream (with credentials that are machine-generated and no one sees), and presenting oauth to an end-user. In that scenario, the above options aren't particularly useful. This PR adds a parameter to allow passing a basic auth password AND user to an upstream. We can still pass X-Forwarded-User and X-Forwarded-Email as additional headers, but the username passed with the auth header is not just a duplicate of the X-Forwarded-User.