### PR TITLE
Roles header with refresh configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Usage of oauth2_proxy:
   -pass-access-token=false: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
   -pass-basic-auth=true: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
   -pass-host-header=true: pass the request Host Header to upstream
+  -pass-roles-header=true: pass user's roles upstream via X-Forwarded-Roles header
   -profile-url="": Profile access endpoint
   -provider="google": OAuth provider
   -proxy-prefix="/oauth2": the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Usage of oauth2_proxy:
   -pass-access-token=false: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
   -pass-basic-auth=true: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
   -pass-host-header=true: pass the request Host Header to upstream
-  -pass-roles-header=true: pass user's roles upstream via X-Forwarded-Roles header
+  -pass-roles-header=false: pass user's roles upstream via X-Forwarded-Roles header
   -profile-url="": Profile access endpoint
   -provider="google": OAuth provider
   -proxy-prefix="/oauth2": the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -41,6 +41,9 @@
 ## Pass OAuth Access token to upstream via "X-Forwarded-Access-Token"
 # pass_access_token = false
 
+## Pass roles the user has via X-Forwarded-Roles
+# pass_roles_header = true
+
 ## Authenticated Email Addresses File (one email per line)
 # authenticated_emails_file = ""
 

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -42,7 +42,7 @@
 # pass_access_token = false
 
 ## Pass roles the user has via X-Forwarded-Roles
-# pass_roles_header = true
+# pass_roles_header = false
 
 ## Authenticated Email Addresses File (one email per line)
 # authenticated_emails_file = ""

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
+	flagSet.Bool("pass-roles-header", false, "pass user's teams upstream via X-Forwarded-Roles header")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -30,6 +30,7 @@ var SignatureHeaders []string = []string{
 	"X-Forwarded-User",
 	"X-Forwarded-Email",
 	"X-Forwarded-Access-Token",
+	"X-Forwarded-Roles",
 	"Cookie",
 	"Gap-Auth",
 }
@@ -61,6 +62,7 @@ type OAuthProxy struct {
 	PassBasicAuth       bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
+	PassRolesHeader     bool
 	CookieCipher        *cookie.Cipher
 	skipAuthRegex       []string
 	compiledRegex       []*regexp.Regexp
@@ -195,6 +197,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		PassBasicAuth:     opts.PassBasicAuth,
 		BasicAuthPassword: opts.BasicAuthPassword,
 		PassAccessToken:   opts.PassAccessToken,
+		PassRolesHeader:   opts.PassRolesHeader,
 		CookieCipher:      cipher,
 		templates:         loadTemplates(opts.CustomTemplatesDir),
 	}
@@ -596,6 +599,11 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}
 	}
+
+	if p.PassRolesHeader {
+		req.Header["X-Forwarded-Roles"] = []string{"our_roles"}
+	}
+
 	if session.Email == "" {
 		rw.Header().Set("GAP-Auth", session.User)
 	} else {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -601,10 +601,13 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 
 	if p.PassRolesHeader {
-
-		// Todo - pull team list
-		log.Printf("Provider data - %v", p.provider.Data())
-		req.Header["X-Forwarded-Roles"] = []string{"admin,kindly"}
+		type RoleProvider interface {
+			GetUserRoles() string
+		}
+		rp := p.provider.(RoleProvider);
+		rp.GetUserRoles();
+		log.Printf("User role data - %v", rp.GetUserRoles())
+		req.Header["X-Forwarded-Roles"] = []string{rp.GetUserRoles()}
 	}
 
 	if session.Email == "" {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -530,6 +530,9 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 	if session != nil && sessionAge > p.CookieRefresh && p.CookieRefresh != time.Duration(0) {
 		log.Printf("%s refreshing %s old session cookie for %s (refresh after %s)", remoteAddr, sessionAge, session, p.CookieRefresh)
+		log.Printf("Refreshing role permissions for user")
+		rp := p.provider.(providers.RoleProvider)
+		rp.SetUserRoles(session.AccessToken)
 		saveSession = true
 	}
 
@@ -603,8 +606,22 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	if p.PassRolesHeader {
 		rp := p.provider.(providers.RoleProvider)
 		roles := rp.GetUserRoles()
-		log.Printf("User role data - %v", roles)
-		req.Header["X-Forwarded-Roles"] = []string{roles}
+
+		// Upon restarting the proxy, if there is an existing cookie, we need to re-fetch roles from provider
+		// Project preference is to avoid cookie bloat, so we aren't storing roles in the cookie
+		// https://github.com/bitly/oauth2_proxy/issues/174#issuecomment-1578273584
+		var i = 0
+		if len(roles) < 1  && i < 1 {
+			i++
+			rp.SetUserRoles(session.AccessToken)
+			refreshedRoles := rp.GetUserRoles()
+			req.Header["X-Forwarded-Roles"] = []string{refreshedRoles}
+			log.Printf("Refreshed user role data - %v", refreshedRoles)
+
+		} else {
+			req.Header["X-Forwarded-Roles"] = []string{roles}
+			log.Printf("User role data - %v", roles)
+		}
 	}
 
 	if session.Email == "" {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -604,8 +604,8 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		type RoleProvider interface {
 			GetUserRoles() string
 		}
-		rp := p.provider.(RoleProvider);
-		rp.GetUserRoles();
+		rp := p.provider.(RoleProvider)
+		rp.GetUserRoles()
 		log.Printf("User role data - %v", rp.GetUserRoles())
 		req.Header["X-Forwarded-Roles"] = []string{rp.GetUserRoles()}
 	}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -601,7 +601,10 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 
 	if p.PassRolesHeader {
-		req.Header["X-Forwarded-Roles"] = []string{"our_roles"}
+
+		// Todo - pull team list
+		log.Printf("Provider data - %v", p.provider.Data())
+		req.Header["X-Forwarded-Roles"] = []string{"admin,kindly"}
 	}
 
 	if session.Email == "" {

--- a/options.go
+++ b/options.go
@@ -177,6 +177,20 @@ func (o *Options) Validate() error {
 			o.CookieExpire.String()))
 	}
 
+	// Todo - Read up on Go syntax and clean this up
+	// Confirm the provider type supports sending user roles
+	if o.PassRolesHeader {
+		type RoleProvider interface {
+			GetUserRoles() string
+		}
+		if rp, ok := o.provider.(RoleProvider); ok{
+			rp.GetUserRoles();
+		} else {
+			msgs = append(msgs, "Provider '" + o.provider.Data().ProviderName + "' does not support sending a roles header.")
+		}
+	}
+
+
 	if len(o.GoogleGroups) > 0 || o.GoogleAdminEmail != "" || o.GoogleServiceAccountJSON != "" {
 		if len(o.GoogleGroups) < 1 {
 			msgs = append(msgs, "missing setting: google-group")

--- a/options.go
+++ b/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken   bool     `flag:"pass-access-token" cfg:"pass_access_token"`
 	PassHostHeader    bool     `flag:"pass-host-header" cfg:"pass_host_header"`
+	PassRolesHeader   bool     `flag:"pass-roles-header" cfg:"pass_roles_header"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -93,6 +94,7 @@ func NewOptions() *Options {
 		PassBasicAuth:       true,
 		PassAccessToken:     false,
 		PassHostHeader:      true,
+		PassRolesHeader:     true,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
 	}

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-
 	"github.com/bitly/oauth2_proxy/cookie"
 )
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -23,6 +23,7 @@ type Provider interface {
 // is a member of.
 type RoleProvider interface {
 	GetUserRoles() string
+	SetUserRoles(string) (bool, error)
 }
 
 // New gives you an instance of the given provider


### PR DESCRIPTION
This enhancement provides a new configuration to send roles as a header with an implementation for the Github provider. 

Roles are not stored in the cookie (per https://github.com/bitly/oauth2_proxy/issues/174#issuecomment-1578273584) but in the case of a restart of the oauth2_proxy application, the roles are retrieved. 

Additionally, metered updates of roles can be enabled with the cookie-refresh configuration to apply privilege changes to the current session.