### PR TITLE
Validate cookie name 

### DIFF
--- a/options.go
+++ b/options.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -200,6 +201,7 @@ func (o *Options) Validate() error {
 	}
 
 	msgs = parseSignatureKey(o, msgs)
+	msgs = validateCookieName(o, msgs)
 
 	if len(msgs) != 0 {
 		return fmt.Errorf("Invalid configuration:\n  %s",
@@ -257,6 +259,14 @@ func parseSignatureKey(o *Options, msgs []string) []string {
 			o.SignatureKey)
 	} else {
 		o.signatureData = &SignatureData{hash, secretKey}
+	}
+	return msgs
+}
+
+func validateCookieName(o *Options, msgs []string) []string {
+	cookie := &http.Cookie{Name: o.CookieName}
+	if cookie.String() == "" {
+		return append(msgs, "invalid cookie name: "+o.CookieName)
 	}
 	return msgs
 }

--- a/options.go
+++ b/options.go
@@ -266,7 +266,7 @@ func parseSignatureKey(o *Options, msgs []string) []string {
 func validateCookieName(o *Options, msgs []string) []string {
 	cookie := &http.Cookie{Name: o.CookieName}
 	if cookie.String() == "" {
-		return append(msgs, "invalid cookie name: "+o.CookieName)
+		return append(msgs, fmt.Sprintf("invalid cookie name: %q", o.CookieName))
 	}
 	return msgs
 }

--- a/options_test.go
+++ b/options_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto"
+	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -228,5 +229,5 @@ func TestValidateCookieBadName(t *testing.T) {
 	o.CookieName = "_bad_cookie_name{}"
 	err := o.Validate()
 	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
-		"  invalid cookie name: "+o.CookieName)
+		fmt.Sprintf("  invalid cookie name: %q", o.CookieName))
 }

--- a/options_test.go
+++ b/options_test.go
@@ -216,3 +216,17 @@ func TestValidateSignatureKeyUnsupportedAlgorithm(t *testing.T) {
 	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
 		"  unsupported signature hash algorithm: "+o.SignatureKey)
 }
+
+func TestValidateCookie(t *testing.T) {
+	o := testOptions()
+	o.CookieName = "_valid_cookie_name"
+	assert.Equal(t, nil, o.Validate())
+}
+
+func TestValidateCookieBadName(t *testing.T) {
+	o := testOptions()
+	o.CookieName = "_bad_cookie_name{}"
+	err := o.Validate()
+	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
+		"  invalid cookie name: "+o.CookieName)
+}


### PR DESCRIPTION
This fixes #264 

`(http.Cookie).String()` will silently return an empty string when the cookie name contains a rune not in the following table https://github.com/golang/net/blob/master/lex/httplex/httplex.go#L17

With this patch I've added an additional validator to check the cookie name at boot. I've had to 'mock' a `http.Cookie` as the http package doesn't export the check function, here: https://github.com/golang/go/blob/master/src/net/http/cookie.go#L368

Regards,
James