### PR TITLE
Strip sensitive URL parameters from provider log output

### DIFF
--- a/providers/github.go
+++ b/providers/github.go
@@ -85,7 +85,8 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 		return false, err
 	}
 	if resp.StatusCode != 200 {
-		return false, fmt.Errorf("got %d from %q %s", resp.StatusCode, endpoint, body)
+		return false, fmt.Errorf(
+			"got %d from %q %s", resp.StatusCode, stripToken(endpoint.String()), body)
 	}
 
 	if err := json.Unmarshal(body, &orgs); err != nil {
@@ -140,7 +141,8 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 		return false, err
 	}
 	if resp.StatusCode != 200 {
-		return false, fmt.Errorf("got %d from %q %s", resp.StatusCode, endpoint, body)
+		return false, fmt.Errorf(
+			"got %d from %q %s", resp.StatusCode, stripToken(endpoint.String()), body)
 	}
 
 	if err := json.Unmarshal(body, &teams); err != nil {
@@ -217,9 +219,10 @@ func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 	}
 
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("got %d from %q %s", resp.StatusCode, endpoint, body)
+		return "", fmt.Errorf("got %d from %q %s",
+			resp.StatusCode, stripToken(endpoint.String()), body)
 	} else {
-		log.Printf("got %d from %q %s", resp.StatusCode, endpoint, body)
+		log.Printf("got %d from %q %s", resp.StatusCode, stripToken(endpoint.String()), body)
 	}
 
 	if err := json.Unmarshal(body, &emails); err != nil {

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -119,3 +119,14 @@ func TestValidateSessionStateExpiredToken(t *testing.T) {
 	vt_test.response_code = 401
 	assert.Equal(t, false, validateToken(vt_test.provider, "foobar", nil))
 }
+
+func TestStripTokenNotPresent(t *testing.T) {
+	test := "http://local.test/api/test?a=1&b=2"
+	assert.Equal(t, test, stripToken(test))
+}
+
+func TestStripToken(t *testing.T) {
+	test := "http://local.test/api/test?access_token=deadbeef&b=1&c=2"
+	expected := "http://local.test/api/test?access_token=dead...&b=1&c=2"
+	assert.Equal(t, expected, stripToken(test))
+}


### PR DESCRIPTION
Resolves #291 

After searching through the providers package manually, I determined the GitHub provider and `validateToken` helper function were the only areas at risk here. Other providers, like Google, encode their sensitive parameters as a form-encoded body, and they are never logged.

@jehiah 