### PR TITLE
Interop for github provider and EmailDomains

### DIFF
--- a/options.go
+++ b/options.go
@@ -212,10 +212,11 @@ func (o *Options) Validate() error {
 
 func parseProviderInfo(o *Options, msgs []string) []string {
 	p := &providers.ProviderData{
-		Scope:          o.Scope,
-		ClientID:       o.ClientID,
-		ClientSecret:   o.ClientSecret,
-		ApprovalPrompt: o.ApprovalPrompt,
+		Scope:                 o.Scope,
+		ClientID:              o.ClientID,
+		ClientSecret:          o.ClientSecret,
+		ApprovalPrompt:        o.ApprovalPrompt,
+		PreferredEmailDomains: o.EmailDomains,
 	}
 	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
 	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)

--- a/providers/github.go
+++ b/providers/github.go
@@ -179,7 +179,6 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 }
 
 func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
-
 	var emails []struct {
 		Email   string `json:"email"`
 		Primary bool   `json:"primary"`
@@ -229,6 +228,16 @@ func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 		return "", fmt.Errorf("%s unmarshaling %s", err, body)
 	}
 
+	for _, domain := range p.PreferredEmailDomains {
+		if domain == "*" {
+			break
+		}
+		for _, email := range emails {
+			if strings.HasSuffix(email.Email, domain) {
+				return email.Email, nil
+			}
+		}
+	}
 	for _, email := range emails {
 		if email.Primary {
 			return email.Email, nil

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,16 +5,17 @@ import (
 )
 
 type ProviderData struct {
-	ProviderName      string
-	ClientID          string
-	ClientSecret      string
-	LoginURL          *url.URL
-	RedeemURL         *url.URL
-	ProfileURL        *url.URL
-	ProtectedResource *url.URL
-	ValidateURL       *url.URL
-	Scope             string
-	ApprovalPrompt    string
+	ProviderName          string
+	ClientID              string
+	ClientSecret          string
+	LoginURL              *url.URL
+	RedeemURL             *url.URL
+	ProfileURL            *url.URL
+	ProtectedResource     *url.URL
+	ValidateURL           *url.URL
+	Scope                 string
+	ApprovalPrompt        string
+	PreferredEmailDomains []string
 }
 
 func (p *ProviderData) Data() *ProviderData { return p }


### PR DESCRIPTION
People (like my coworkers) often use the same github account for both work and other purposes. As such they end up having multiple email addresses set up for the same account

When using the pass-basic-auth, the X-Forwarded-Email and X-Forwarded-User end up passing their primary email and prefix thereof, which due to githubs configurability of notifications, may or may not be their work email. For systems which use the values of these headers to autovivify downstream users, confusion is introduced into the naming schemes, and in especially bad cases you could accidentally end up sending confidential notifications out of band.

While obviously there are more policy-level solutions, this is my proposal at a technical solution.

I suspect there may be a better way to achieve it, but this is a first pass; Let me know what you think.  Thanks :D
