### PR TITLE
sign_in template form input redirect value is not updating as expected.

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -130,14 +130,13 @@ func getTemplates() *template.Template {
 	</div>
 	{{ end }}
 	<script>
-		if (window.location.hash) {
-			(function() {
-				var inputs = document.getElementsByName('rd');
-				for (var i = 0; i < inputs.length; i++) {
-					inputs[i].value += window.location.hash;
-				}
-			})();
-		}
+		(function() {
+			var inputs = document.getElementsByName('rd');
+			var redirect = window.location.pathname + window.location.hash;
+			for (var i = 0; i < inputs.length; i++) {
+				inputs[i].value = redirect;
+			}
+		})();
 	</script>
 	<footer>
 	{{ if eq .Footer "-" }}


### PR DESCRIPTION
The use case for this change is, suppose oauth2_proxy is running on `https://companydomain/dashboard` , after successful authentication oauth2_proxy is not redirecting back to `/dashboard `where the request has started.

The reason for this behavior is `redirect-url` config option is not updating sign_in template `"{{.Redirect}}"` value as expected because of this [check](https://github.com/bitly/oauth2_proxy/blob/master/oauthproxy.go#L338).

[ pull request](https://github.com/bitly/oauth2_proxy/pull/160) for this fix had already raised but seems like its not merged yet.  

Other option is to update the hidden field value of sign_in template input form with `window.location.pathname` so that after authentication, oauth2_proxy returns the request back to the same redirect url which mentioned in the form input hidden field `rd`.