### PR TITLE
Discovery backends by listening to kubernetes services.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -7,3 +7,4 @@ gopkg.in/fsnotify.v1                     v1.2.0
 golang.org/x/oauth2                      04e1573abc896e70388bd387a69753c378d46466
 golang.org/x/oauth2/google               04e1573abc896e70388bd387a69753c378d46466
 google.golang.org/api/admin/directory/v1 a5c3e2a4792aff40e59840d9ecdff0542a202a80
+k8s.io/client-go		 93fcd402979cfad8a7151f96e016416947c6a3cb

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,0 +1,28 @@
+package discovery
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// Discovery defines the interface for backend discovery
+type Discovery interface {
+	NewServeMux(http.Handler) http.Handler
+}
+
+type nullDiscovery struct {
+}
+
+func (n *nullDiscovery) NewServeMux(mux http.Handler) http.Handler {
+	return mux
+}
+
+// Create allocates the discovery provider based on the configuration.
+func Create(provider string, proxyAllocator func(u *url.URL) http.Handler) Discovery {
+	switch provider {
+	case "kubernetes":
+		return newKubernetesDiscovery(proxyAllocator)
+	default:
+		return &nullDiscovery{}
+	}
+}

--- a/discovery/kubernetes.go
+++ b/discovery/kubernetes.go
@@ -1,0 +1,279 @@
+package discovery
+
+import (
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"k8s.io/client-go/1.4/kubernetes"
+	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/1.4/pkg/watch"
+	"k8s.io/client-go/1.4/rest"
+)
+
+type svcEndpoint struct {
+	Path string
+	Port int32
+}
+
+type k8sDiscovery struct {
+	proxyAllocator func(u *url.URL) http.Handler
+	pathHandlers   map[string]http.Handler
+	services       map[string]*svcEndpoint
+	defaultHandler http.Handler
+	statusTmpl     *template.Template
+}
+
+const (
+	// OAuth2ProxyPathAnnotation is the annotation used by a kubernetes service
+	// to add a specific string to the list of paths handled by this proxy.
+	OAuth2ProxyPathAnnotation = "oauth2-proxy/path"
+
+	// OAuth2ProxyPortAnnotation specifies the HTTP port to forward traffic to.
+	OAuth2ProxyPortAnnotation = "oauth2-proxy/port"
+
+	discoveryStatusPage = "/oauth2/discovery"
+)
+
+// ServeHttp implements the http.Handler interface.
+// It is called to demux request paths.
+func (k *k8sDiscovery) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	switch req.URL.Path {
+	case discoveryStatusPage:
+		k.statusPage(rw, req)
+		return
+	}
+
+	var bestMatch string
+	handler := k.defaultHandler
+	for k, v := range k.pathHandlers {
+		if strings.HasPrefix(req.URL.Path, k) && len(k) > len(bestMatch) {
+			bestMatch = k
+			handler = v
+		}
+	}
+
+	handler.ServeHTTP(rw, req)
+}
+
+func (k *k8sDiscovery) NewServeMux(mux http.Handler) http.Handler {
+	k.defaultHandler = mux
+	return k
+}
+
+const statusTemplate = `<!DOCTYPE html>
+<html lang="en" charset="utf-8">
+<head>
+	<title>Kubernetes Service Discovery</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<style>
+	body {
+		font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+		font-size: 14px;
+		line-height: 1.42857143;
+		color: #333;
+		background: #f0f0f0;
+	}
+    div.centered {
+        text-align: center;
+    }
+    div.centered table {
+        margin: 0 auto;
+        text-align: left;
+    }
+    </style>
+</head>
+<body>
+<div class="centered">
+<table>
+    <thead>
+        <tr>
+            <th>Service</th>
+            <th>Port</th>
+            <th>Path</th>
+        </tr>
+    </thead>
+    <tbody>
+{{ range $key, $value := . }}
+    <tr>
+        <td>{{ $key }}</td>
+        <td>{{ if ge $value.Port 0 }}{{ $value.Port }}{{ end }}</td>
+        <td><a href="{{ $value.Path }}">{{ $value.Path }}</a></td>
+    </tr>
+{{ end }}
+    </tbody>
+</table>
+</div>
+</body>
+</html>
+`
+
+func (k *k8sDiscovery) statusPage(w http.ResponseWriter, r *http.Request) {
+	k.statusTmpl.Execute(w, k.services)
+}
+
+func getServicePort(svc *v1.Service) (int32, bool) {
+	if port, exists := svc.Annotations[OAuth2ProxyPortAnnotation]; exists {
+		p, err := strconv.Atoi(port)
+		if err != nil {
+			log.Printf("Invalid annotation (%s) for %s/%s", port, svc.Namespace, svc.Name)
+			return -1, false
+		}
+		return int32(p), true
+	} else if len(svc.Spec.Ports) == 1 {
+		svcPort := svc.Spec.Ports[0]
+		if svcPort.Port != 80 {
+			return svcPort.Port, true
+		}
+	}
+	return -1, false
+}
+
+func makeSvcEndpoint(svc *v1.Service) *svcEndpoint {
+	path, exists := svc.Annotations[OAuth2ProxyPathAnnotation]
+	if !exists {
+		return nil
+	}
+	endpoint := &svcEndpoint{
+		Path: path,
+		Port: -1,
+	}
+	if port, isSet := getServicePort(svc); isSet {
+		endpoint.Port = port
+	}
+	return endpoint
+}
+
+func makeServiceURL(svc *v1.Service, endpoint *svcEndpoint) *url.URL {
+	schemeHost := fmt.Sprintf("http://%s.%s.svc", svc.Name, svc.Namespace)
+	if endpoint.Port >= 0 {
+		schemeHost += fmt.Sprintf(":%d", endpoint.Port)
+	}
+
+	u, err := url.Parse(schemeHost)
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+	return u
+}
+
+func (k *k8sDiscovery) serviceAdd(svc *v1.Service) {
+	endpoint := makeSvcEndpoint(svc)
+	if endpoint == nil {
+		return
+	}
+
+	svcID := svc.Namespace + "/" + svc.Name
+	log.Println("ADD service", svcID)
+
+	if prev, dup := k.services[svcID]; dup {
+		log.Printf("ADD event for existing service %s", svcID)
+		if reflect.DeepEqual(endpoint, prev) {
+			return
+		}
+		delete(k.pathHandlers, endpoint.Path)
+	}
+
+	if _, dup := k.pathHandlers[endpoint.Path]; dup {
+		log.Printf("Duplicate %s annotation for %s: %s/%s", OAuth2ProxyPathAnnotation, endpoint.Path, svc.Namespace, svc.Name)
+		return
+	}
+
+	u := makeServiceURL(svc, endpoint)
+	k.pathHandlers[endpoint.Path] = k.proxyAllocator(u)
+	k.services[svcID] = endpoint
+}
+
+func (k *k8sDiscovery) serviceDelete(svc *v1.Service) {
+	svcID := svc.Namespace + "/" + svc.Name
+	log.Println("DELETE service", svcID)
+	if endpoint, exists := k.services[svcID]; exists {
+		delete(k.services, svcID)
+		delete(k.pathHandlers, endpoint.Path)
+	}
+}
+
+func (k *k8sDiscovery) serviceChange(svc *v1.Service) {
+	svcID := svc.Namespace + "/" + svc.Name
+	prev := k.services[svcID]
+	endpoint := makeSvcEndpoint(svc)
+
+	if prev != nil && endpoint != nil {
+		if reflect.DeepEqual(prev, endpoint) {
+			return
+		}
+
+		log.Println("CHANGE service", svcID)
+		u := makeServiceURL(svc, endpoint)
+		k.pathHandlers[endpoint.Path] = k.proxyAllocator(u)
+		delete(k.pathHandlers, prev.Path)
+		k.services[svcID] = endpoint
+	} else if endpoint != nil {
+		k.serviceAdd(svc)
+	} else if prev != nil {
+		k.serviceDelete(svc)
+	}
+}
+
+func (k *k8sDiscovery) run(watcher watch.Interface) {
+	var shutdown bool
+	for !shutdown {
+		select {
+		case ev, ok := <-watcher.ResultChan():
+			if !ok {
+				shutdown = true
+				break
+			}
+			switch ev.Type {
+			case watch.Added:
+				k.serviceAdd(ev.Object.(*v1.Service))
+			case watch.Deleted:
+				k.serviceDelete(ev.Object.(*v1.Service))
+			case watch.Modified:
+				k.serviceChange(ev.Object.(*v1.Service))
+			}
+		}
+	}
+}
+
+func newKubernetesDiscovery(proxyAllocator func(u *url.URL) http.Handler) *k8sDiscovery {
+	log.Println("Enabling kubernetes service discovery")
+
+	// creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	watcher, err := clientset.Core().Services("").Watch(api.ListOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tmpl, err := template.New("status").Parse(statusTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+	k8s := &k8sDiscovery{
+		proxyAllocator: proxyAllocator,
+		pathHandlers:   make(map[string]http.Handler),
+		services:       make(map[string]*svcEndpoint),
+		statusTmpl:     tmpl,
+	}
+
+	go k8s.run(watcher)
+
+	return k8s
+}

--- a/discovery/kubernetes_test.go
+++ b/discovery/kubernetes_test.go
@@ -1,0 +1,175 @@
+package discovery
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/1.4/pkg/watch"
+)
+
+type fakeHTTPHandler struct {
+}
+
+func (h *fakeHTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+}
+
+func fakeProxyAllocator(u *url.URL) http.Handler {
+	return &fakeHTTPHandler{}
+}
+
+func newKubernetesTest(wg *sync.WaitGroup) (*k8sDiscovery, *watch.FakeWatcher) {
+	k8s := &k8sDiscovery{
+		proxyAllocator: fakeProxyAllocator,
+		pathHandlers:   make(map[string]http.Handler),
+		services:       make(map[string]*svcEndpoint),
+	}
+
+	watcher := watch.NewFake()
+	wg.Add(1)
+
+	go func() {
+		k8s.run(watcher)
+		wg.Done()
+	}()
+
+	return k8s, watcher
+}
+
+func TestServiceAdd(t *testing.T) {
+	var wg sync.WaitGroup
+	k8s, watcher := newKubernetesTest(&wg)
+
+	watcher.Add(
+		&v1.Service{
+			ObjectMeta: v1.ObjectMeta{Namespace: "default", Name: "foo"},
+		})
+
+	watcher.Add(
+		&v1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace:   "default",
+				Name:        "bar",
+				Annotations: map[string]string{OAuth2ProxyPathAnnotation: "xxx"},
+			},
+		})
+
+	watcher.Stop()
+	wg.Wait()
+
+	if len(k8s.services) != 1 {
+		t.Errorf("Expected 1 service, got %d", len(k8s.services))
+	}
+}
+
+func TestServiceDelete(t *testing.T) {
+	var wg sync.WaitGroup
+	k8s, watcher := newKubernetesTest(&wg)
+
+	services := []*v1.Service{
+		&v1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace:   "default",
+				Name:        "foo",
+				Annotations: map[string]string{OAuth2ProxyPathAnnotation: "xxx"},
+			},
+		},
+		&v1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace:   "default",
+				Name:        "bar",
+				Annotations: map[string]string{OAuth2ProxyPathAnnotation: "xxy"},
+			},
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{v1.ServicePort{Port: 8080}},
+			},
+		},
+	}
+
+	for _, obj := range services {
+		watcher.Add(obj)
+	}
+
+	watcher.Delete(
+		&v1.Service{
+			ObjectMeta: v1.ObjectMeta{Namespace: "default", Name: "foo"},
+		})
+
+	watcher.Stop()
+	wg.Wait()
+
+	if len(k8s.services) != 1 {
+		t.Errorf("Expected 1 service, got %d", len(k8s.services))
+	}
+
+	if endpoint, exists := k8s.services["default/bar"]; exists {
+		if endpoint.Port != 8080 {
+			t.Errorf("Expected port 8080, got %d", endpoint.Port)
+		}
+	} else {
+		t.Error("Service not found")
+	}
+}
+
+func TestServiceChange(t *testing.T) {
+	var wg sync.WaitGroup
+	k8s, watcher := newKubernetesTest(&wg)
+
+	svc := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace:   "default",
+			Name:        "foo",
+			Annotations: map[string]string{OAuth2ProxyPathAnnotation: "xxx"},
+		},
+	}
+
+	watcher.Add(svc)
+	watcher.Stop()
+	wg.Wait()
+
+	watcher = watch.NewFake()
+	wg.Add(1)
+	go func() {
+		k8s.run(watcher)
+		wg.Done()
+	}()
+
+	svc.ObjectMeta.Annotations[OAuth2ProxyPathAnnotation] = "yyy"
+	watcher.Modify(svc)
+
+	watcher.Stop()
+	wg.Wait()
+
+	if len(k8s.services) != 1 {
+		t.Errorf("Expected 1 service, got %d", len(k8s.services))
+	}
+	if len(k8s.pathHandlers) != 1 {
+		t.Errorf("Expected 1 paths, got %d", len(k8s.pathHandlers))
+	}
+	path := svc.ObjectMeta.Annotations[OAuth2ProxyPathAnnotation]
+	if _, exists := k8s.pathHandlers[path]; !exists {
+		t.Error(path)
+	}
+}
+
+func TestStatusTemplate(t *testing.T) {
+	tmpl, err := template.New("test").Parse(statusTemplate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testData := map[string]*svcEndpoint{
+		"default/foo": &svcEndpoint{"/foo/", -1},
+		"default/bar": &svcEndpoint{"/bar/", 9090},
+	}
+
+	b := new(bytes.Buffer)
+	err = tmpl.Execute(b, testData)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
 
 	flagSet.String("provider", "google", "OAuth provider")
+	flagSet.String("discovery", "", "Backend auto-discovery plugin")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/18F/hmacauth"
 	"github.com/bitly/oauth2_proxy/cookie"
+	"github.com/bitly/oauth2_proxy/discovery"
 	"github.com/bitly/oauth2_proxy/providers"
 )
 
@@ -53,6 +54,7 @@ type OAuthProxy struct {
 
 	redirectURL         *url.URL // the url to receive requests at
 	provider            providers.Provider
+	discovery           discovery.Discovery
 	ProxyPrefix         string
 	SignInMessage       string
 	HtpasswdFile        *HtpasswdFile
@@ -110,6 +112,21 @@ func NewFileServer(path string, filesystemPath string) (proxy http.Handler) {
 	return http.StripPrefix(path, http.FileServer(http.Dir(filesystemPath)))
 }
 
+type httpHandleAllocator struct {
+	auth           hmacauth.HmacAuth
+	passHostHeader bool
+}
+
+func (h *httpHandleAllocator) NewHandler(u *url.URL) http.Handler {
+	proxy := NewReverseProxy(u)
+	if !h.passHostHeader {
+		setProxyUpstreamHostHeader(proxy, u)
+	} else {
+		setProxyDirector(proxy)
+	}
+	return &UpstreamProxy{u.Host, proxy, h.auth}
+}
+
 func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
 	var auth hmacauth.HmacAuth
@@ -117,20 +134,14 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		auth = hmacauth.NewHmacAuth(sigData.hash, []byte(sigData.key),
 			SignatureHeader, SignatureHeaders)
 	}
+	proxyAllocator := &httpHandleAllocator{auth, opts.PassHostHeader}
 	for _, u := range opts.proxyURLs {
 		path := u.Path
 		switch u.Scheme {
 		case "http", "https":
 			u.Path = ""
 			log.Printf("mapping path %q => upstream %q", path, u)
-			proxy := NewReverseProxy(u)
-			if !opts.PassHostHeader {
-				setProxyUpstreamHostHeader(proxy, u)
-			} else {
-				setProxyDirector(proxy)
-			}
-			serveMux.Handle(path,
-				&UpstreamProxy{u.Host, proxy, auth})
+			serveMux.Handle(path, proxyAllocator.NewHandler(u))
 		case "file":
 			if u.Fragment != "" {
 				path = u.Fragment
@@ -170,6 +181,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		}
 	}
 
+	discovery := discovery.Create(opts.Discovery, proxyAllocator.NewHandler)
 	return &OAuthProxy{
 		CookieName:     opts.CookieName,
 		CookieSeed:     opts.CookieSecret,
@@ -189,7 +201,8 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 
 		ProxyPrefix:        opts.ProxyPrefix,
 		provider:           opts.provider,
-		serveMux:           serveMux,
+		discovery:          discovery,
+		serveMux:           discovery.NewServeMux(serveMux),
 		redirectURL:        redirectURL,
 		skipAuthRegex:      opts.SkipAuthRegex,
 		compiledRegex:      opts.CompiledRegex,

--- a/options.go
+++ b/options.go
@@ -70,6 +70,9 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
+	// Backend discovery
+	Discovery string `flag:"discovery" cfg:"discovery" env:"OAUTH2_PROXY_DISCOVERY"`
+
 	// internal values that are set after config validation
 	redirectURL   *url.URL
 	proxyURLs     []*url.URL


### PR DESCRIPTION
This patch has the ability for the oauth2_proxy to automatically discovery kubernetes services.

In my current job, we use GKE for all of our services, which typically expose debug ports that we want to maintain under access control. In order to limit the access we use an oauth2-proxy with external access (via GCE LoadBalancer) that demuxes into multiple internal services. So far we have been modifying a configuration file when services are launched but that introduces extra manual work.


The following is an example configuration for a kubernetes service:

```
apiVersion: v1
kind: Service
metadata:
  name: embedding-svc
  namespace: roque
  annotations:
    oauth2-proxy/path: /embedding_svc/
spec:
  ports:
    - name: default
      port: 8080
      targetPort: 8080
  selector:
    run: embedding-dvc
```

The annotation ```oauth2-proxy/path``` causes the discovery module to create URL forwarding rule.
As far as i understand it, the oauth2-proxy operation is the same for dynamically learnt paths or paths discovered via the configuration file.

Please consider incorporating this functionality. I apologize in advance for not being aware of the coding conventions used in the project. I'm willing to refactor the code to comply with them but would appreciate guidance.