### PR TITLE
WIP: LetsEncrypt Support via rsc.io/letsencrypt

### DIFF
--- a/http.go
+++ b/http.go
@@ -15,8 +15,6 @@ import (
 type Server struct {
 	Handler http.Handler
 	Opts    *Options
-
-	m *letsencrypt.Manager
 }
 
 func (s *Server) ListenAndServe() {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ func main() {
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
+
+	flagSet.Bool("letsencrypt-enabled", false, "use letsencrypt")
+	flagSet.String("letsencrypt-cache-dir", "./", "letsencrypt certificate cache directory")
+	flagSet.String("letsencrypt-admin-email", "", "letsencrypt admin email")
+	flagSet.String("letsencrypt-domain", "", "domain to secure with letsencrypt")
+
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")

--- a/options.go
+++ b/options.go
@@ -26,6 +26,10 @@ type Options struct {
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
+	LetsEncryptEnabled    bool   `flag:"letsencrypt-enabled" cfg:"letsencrypt-enabled"`
+	LetsEncryptCacheDir   string `flag:"letsencrypt-cache-dir" cfg:"letsencrypt-cache-dir"`
+	LetsEncryptAdminEmail string `flag:"letsencrypt-admin-email" cfg:"letsencrypt-admin-email"`
+
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
@@ -128,6 +132,14 @@ func (o *Options) Validate() error {
 	}
 	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
 		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+	}
+
+	if o.LetsEncryptEnabled && (o.TLSCertFile != "" || o.TLSKeyFile != "") {
+		msgs = append(msgs, "cannot enable letsencrypt AND specify a TLS keypair")
+	}
+
+	if o.LetsEncryptEnabled && o.LetsEncryptAdminEmail == "" {
+		msgs = append(msgs, "must set letsencrypt-admin-email if letsencrypt is enabled")
 	}
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)

--- a/options_test.go
+++ b/options_test.go
@@ -54,6 +54,19 @@ func TestGoogleGroupOptions(t *testing.T) {
 	assert.Equal(t, expected, err.Error())
 }
 
+func TestLetsEncryptOptions(t *testing.T) {
+	o := testOptions()
+	o.LetsEncryptEnabled = true
+	o.TLSCertFile = "key.keyfile"
+	err := o.Validate()
+	assert.NotEqual(t, nil, err)
+
+	expected := errorMsg([]string{
+		"cannot enable letsencrypt AND specify a TLS keypair",
+		"must set letsencrypt-admin-email if letsencrypt is enabled"})
+	assert.Equal(t, expected, err.Error())
+}
+
 func TestGoogleGroupInvalidFile(t *testing.T) {
 	o := testOptions()
 	o.GoogleGroups = []string{"test_group"}


### PR DESCRIPTION
Not finished yet, but opening a WIP PR keeps the work I'm doing on this open 

Allows for automatic fetching and validation of LetsEncrypt SSL certs with a few quick settings :) 

TODO: 
- [ ] Update documentation
- [ ] Really test that it works (haven't done yet)
- [ ] Ensure HTTP -> HTTPS redirects when using LetsEncrypt

This will close #313 
