### PR TITLE
various fixes for getting Nginx auth_request mode working

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,10 +359,25 @@ server {
   }
 
   location /oauth2/ {
-    proxy_pass http://127.0.0.1:4180;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Scheme $scheme;
+    proxy_pass       http://127.0.0.1:4180;
+    proxy_set_header Host                    $host;
+    proxy_set_header X-Real-IP               $remote_addr;
+    proxy_set_header X-Scheme                $scheme;
+    proxy_set_header X-Auth-Request-Redirect $request_uri;
+  }
+
+  location /upstream/ {
+    auth_request /oauth2/auth;
+    error_page 401 = /oauth2/sign_in;
+
+    # pass information via X-User and X-Email headers to backend,
+    # requires running with --set-xauthrequest flag
+    auth_request_set $user   $upstream_http_x_auth_request_user;
+    auth_request_set $email  $upstream_http_x_auth_request_email;
+    proxy_set_header X-User  $user;
+    proxy_set_header X-Email $email;
+
+    proxy_pass http://backend/;
   }
 
   location / {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -363,6 +363,9 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	rw.WriteHeader(code)
 
 	redirect_url := req.URL.RequestURI()
+	if req.Header.Get("X-Auth-Request-Redirect") != "" {
+		redirect_url = req.Header.Get("X-Auth-Request-Redirect")
+	}
 	if redirect_url == p.SignInPath {
 		redirect_url = "/"
 	}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -60,6 +60,7 @@ type OAuthProxy struct {
 	HtpasswdFile        *HtpasswdFile
 	DisplayHtpasswdForm bool
 	serveMux            http.Handler
+	SetXAuthRequest     bool
 	PassBasicAuth       bool
 	SkipProviderButton  bool
 	PassUserHeaders     bool
@@ -198,6 +199,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		redirectURL:        redirectURL,
 		skipAuthRegex:      opts.SkipAuthRegex,
 		compiledRegex:      opts.CompiledRegex,
+		SetXAuthRequest:    opts.SetXAuthRequest,
 		PassBasicAuth:      opts.PassBasicAuth,
 		PassUserHeaders:    opts.PassUserHeaders,
 		BasicAuthPassword:  opts.BasicAuthPassword,
@@ -661,6 +663,12 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		req.Header["X-Forwarded-User"] = []string{session.User}
 		if session.Email != "" {
 			req.Header["X-Forwarded-Email"] = []string{session.Email}
+		}
+	}
+	if p.SetXAuthRequest {
+		rw.Header().Set("X-Auth-Request-User", session.User)
+		if session.Email != "" {
+			rw.Header().Set("X-Auth-Request-Email", session.Email)
 		}
 	}
 	if p.PassAccessToken && session.AccessToken != "" {

--- a/options.go
+++ b/options.go
@@ -57,6 +57,7 @@ type Options struct {
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
+	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -97,6 +98,7 @@ func NewOptions() *Options {
 		CookieHttpOnly:      true,
 		CookieExpire:        time.Duration(168) * time.Hour,
 		CookieRefresh:       time.Duration(0),
+		SetXAuthRequest:     false,
 		PassBasicAuth:       true,
 		PassUserHeaders:     true,
 		PassAccessToken:     false,


### PR DESCRIPTION
This supersedes #173 and #247, with the following changes:

- adds a new flag `--set-xauthrequest` which sets response headers for use in auth_request mode (analogous to the `X-Forwarded-User` and `X-Forwarded-Email` headers in normal mode).
- optionally read the redirect URL from request header `X-Auth-Request-Redirect` as the request URL doesn't correspond to the URL to redirect to in auth_request mode
- documentation updates