### PR TITLE
HTTP to HTTPS redirect listener

### DIFF
--- a/http.go
+++ b/http.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -16,6 +17,9 @@ type Server struct {
 }
 
 func (s *Server) ListenAndServe() {
+	if s.Opts.RedirectHttpToHttps {
+		go s.ServeHTTPSRedirector()
+	}
 	if s.Opts.TLSKeyFile != "" || s.Opts.TLSCertFile != "" {
 		s.ServeHTTPS()
 	} else {
@@ -85,6 +89,12 @@ func (s *Server) ServeHTTPS() {
 	}
 
 	log.Printf("HTTPS: closing %s", tlsListener.Addr())
+}
+
+func (s *Server) ServeHTTPSRedirector() {
+	h := LoggingHandler(os.Stdout, NewRedirectHandler(*s.Opts), s.Opts.RequestLogging)
+	log.Printf("HTTPs redirector listening on: %s", s.Opts.HttpsRedirectorAddress)
+	log.Fatal(http.ListenAndServe(s.Opts.HttpsRedirectorAddress, h))
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func main() {
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
+	flagSet.String("https-redirector-address", ":80", "<addr>:<port> to listen on for HTTPS clients")
+	flagSet.Bool("redirect-http-to-https", false, "Listens on the port specified in https-redirector-address and rewrites to the host and protocol of redirect-url.")
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")

--- a/options.go
+++ b/options.go
@@ -17,14 +17,16 @@ import (
 
 // Configuration Options that can be set by Command Line Flag, or Config File
 type Options struct {
-	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
-	HttpAddress  string `flag:"http-address" cfg:"http_address"`
-	HttpsAddress string `flag:"https-address" cfg:"https_address"`
-	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
-	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
-	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
-	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
+	ProxyPrefix            string `flag:"proxy-prefix" cfg:"proxy-prefix"`
+	HttpAddress            string `flag:"http-address" cfg:"http_address"`
+	HttpsAddress           string `flag:"https-address" cfg:"https_address"`
+	HttpsRedirectorAddress string `flag:"https-redirector-address"`
+	RedirectHttpToHttps    bool   `flag:"redirect-http-to-https"`
+	RedirectURL            string `flag:"redirect-url" cfg:"redirect_url"`
+	ClientID               string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
+	ClientSecret           string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
+	TLSCertFile            string `flag:"tls-cert" cfg:"tls_cert_file"`
+	TLSKeyFile             string `flag:"tls-key" cfg:"tls_key_file"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`

--- a/redirect_handler.go
+++ b/redirect_handler.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type RedirectHandler struct {
+	Opts Options
+}
+
+func NewRedirectHandler(opts Options) RedirectHandler {
+	return RedirectHandler{
+		Opts: opts,
+	}
+}
+
+func (h RedirectHandler) buildRedirectURL(requestURL url.URL) (string, error) {
+	u, err := url.Parse(h.Opts.RedirectURL)
+	if err != nil {
+		return "", err
+	}
+	requestURL.Scheme = u.Scheme
+	requestURL.Host = u.Host
+
+	return requestURL.String(), nil
+}
+
+func (h RedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	u, err := h.buildRedirectURL(*r.URL)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	http.Redirect(w, r, u, http.StatusMovedPermanently)
+}

--- a/redirect_handler_test.go
+++ b/redirect_handler_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func testRedirectorOptions() *Options {
+	o := NewOptions()
+	o.Upstreams = append(o.Upstreams, "http://127.0.0.1:8080/")
+	o.CookieSecret = "foobar"
+	o.ClientID = "bazquux"
+	o.ClientSecret = "xyzzyplugh"
+	o.EmailDomains = []string{"*"}
+	o.RedirectURL = "https://external.com/oauth2/callback"
+	return o
+}
+
+func TestBuildRedirectURL(t *testing.T) {
+	opts := testRedirectorOptions()
+	url, _ := url.Parse("http://internal.com:9000/barkis?a=1&b=2")
+	h := NewRedirectHandler(*opts)
+	out, _ := h.buildRedirectURL(*url)
+
+	assert.Equal(t, out, "https://external.com/barkis?a=1&b=2")
+}
+
+func TestBuildRedirectURLUserAndPass(t *testing.T) {
+	opts := testRedirectorOptions()
+	url, _ := url.Parse("http://charles:dickens@internal.com:9000/boffin?a=1&b=2")
+	h := NewRedirectHandler(*opts)
+	out, _ := h.buildRedirectURL(*url)
+
+	assert.Equal(t, out, "https://charles:dickens@external.com/boffin?a=1&b=2")
+}
+
+func TestBuildRedirectURLFragment(t *testing.T) {
+	opts := testRedirectorOptions()
+	url, _ := url.Parse("http://internal.com:9000/boffin/#test")
+	h := NewRedirectHandler(*opts)
+	out, _ := h.buildRedirectURL(*url)
+
+	assert.Equal(t, out, "https://external.com/boffin/#test")
+}


### PR DESCRIPTION
An attempt to solve #308. I apologize in advance, I'm very new to go. This pr listens on a separate port that will redirect to the host and scheme of the configured `redirect-url`. The thinking is the redirect-url will be the publicly accessible https URL when wanting to re-direct http -> https.

Thanks!