### PR TITLE
Proxy rd argument to sign in form, fallback to RequestUri if not set

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -338,11 +338,6 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	if err != nil {
 		p.ErrorPage(rw, 500, "Internal Error", err.Error())
 		return
-	} else if redirect_url == "/" {
-		redirect_url = req.URL.RequestURI()
-		if redirect_url == p.SignInPath {
-			redirect_url = "/"
-		}
 	}
 
 	t := struct {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -334,9 +334,15 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	p.ClearCookie(rw, req)
 	rw.WriteHeader(code)
 
-	redirect_url := req.URL.RequestURI()
-	if redirect_url == p.SignInPath {
-		redirect_url = "/"
+	redirect_url, err := p.GetRedirect(req)
+	if err != nil {
+		p.ErrorPage(rw, 500, "Internal Error", err.Error())
+		return
+	} else if redirect_url == "/" {
+		redirect_url = req.URL.RequestURI()
+		if redirect_url == p.SignInPath {
+			redirect_url = "/"
+		}
 	}
 
 	t := struct {


### PR DESCRIPTION
The hidden rd input field on the SignIn page ended up being /oauth2/signin?rd=/.... instead of /... when using nginx auth_request.