### PR TITLE
Add env options

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
+	"./cookie"
+	"./providers"
 	"github.com/18F/hmacauth"
-	"github.com/bitly/oauth2_proxy/cookie"
-	"github.com/bitly/oauth2_proxy/providers"
 )
 
 const SignatureHeader = "GAP-Signature"

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"./cookie"
-	"./providers"
 	"github.com/18F/hmacauth"
+	"github.com/articulate/oauth2_proxy/cookie"
+	"github.com/articulate/oauth2_proxy/providers"
 )
 
 const SignatureHeader = "GAP-Signature"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"./providers"
 	"crypto"
 	"encoding/base64"
 	"github.com/18F/hmacauth"
+	"github.com/articulate/oauth2_proxy/providers"
 	"github.com/bmizerany/assert"
 	"io"
 	"io/ioutil"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"./providers"
 	"crypto"
 	"encoding/base64"
 	"github.com/18F/hmacauth"
-	"github.com/bitly/oauth2_proxy/providers"
 	"github.com/bmizerany/assert"
 	"io"
 	"io/ioutil"

--- a/options.go
+++ b/options.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"./providers"
 	"github.com/18F/hmacauth"
-	"github.com/bitly/oauth2_proxy/providers"
 )
 
 // Configuration Options that can be set by Command Line Flag, or Config File

--- a/options.go
+++ b/options.go
@@ -18,7 +18,7 @@ type Options struct {
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	HttpsAddress string `flag:"https-address" cfg:"https_address"`
-	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
+	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url" env:"REDIRECT_URL"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
@@ -44,7 +44,7 @@ type Options struct {
 	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
-	Upstreams         []string `flag:"upstream" cfg:"upstreams"`
+	Upstreams         []string `flag:"upstream" cfg:"upstreams" env:"UPSTREAM"`
 	SkipAuthRegex     []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
 	PassBasicAuth     bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	BasicAuthPassword string   `flag:"basic-auth-password" cfg:"basic_auth_password"`

--- a/options.go
+++ b/options.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"./providers"
 	"github.com/18F/hmacauth"
+	"github.com/articulate/oauth2_proxy/providers"
 )
 
 // Configuration Options that can be set by Command Line Flag, or Config File

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -1,9 +1,9 @@
 package providers
 
 import (
+	"../api"
 	"errors"
 	"fmt"
-	"github.com/bitly/oauth2_proxy/api"
 	"log"
 	"net/http"
 	"net/url"

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -1,9 +1,9 @@
 package providers
 
 import (
-	"../api"
 	"errors"
 	"fmt"
+	"github.com/articulate/oauth2_proxy/api"
 	"log"
 	"net/http"
 	"net/url"

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"../api"
+	"github.com/articulate/oauth2_proxy/api"
 )
 
 // validateToken returns true if token is valid

--- a/providers/internal_util.go
+++ b/providers/internal_util.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/bitly/oauth2_proxy/api"
+	"../api"
 )
 
 // validateToken returns true if token is valid

--- a/providers/linkedin.go
+++ b/providers/linkedin.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/bitly/oauth2_proxy/api"
+	"../api"
 )
 
 type LinkedInProvider struct {

--- a/providers/linkedin.go
+++ b/providers/linkedin.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"../api"
+	"github.com/articulate/oauth2_proxy/api"
 )
 
 type LinkedInProvider struct {

--- a/providers/myusa.go
+++ b/providers/myusa.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"../api"
+	"github.com/articulate/oauth2_proxy/api"
 )
 
 type MyUsaProvider struct {

--- a/providers/myusa.go
+++ b/providers/myusa.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/bitly/oauth2_proxy/api"
+	"../api"
 )
 
 type MyUsaProvider struct {

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/bitly/oauth2_proxy/cookie"
+	"../cookie"
 )
 
 func (p *ProviderData) Redeem(redirectURL, code string) (s *SessionState, err error) {

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"../cookie"
+	"github.com/articulate/oauth2_proxy/cookie"
 )
 
 func (p *ProviderData) Redeem(redirectURL, code string) (s *SessionState, err error) {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,7 +1,7 @@
 package providers
 
 import (
-	"../cookie"
+	"github.com/articulate/oauth2_proxy/cookie"
 )
 
 type Provider interface {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,7 +1,7 @@
 package providers
 
 import (
-	"github.com/bitly/oauth2_proxy/cookie"
+	"../cookie"
 )
 
 type Provider interface {

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"../cookie"
+	"github.com/articulate/oauth2_proxy/cookie"
 )
 
 type SessionState struct {

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitly/oauth2_proxy/cookie"
+	"../cookie"
 )
 
 type SessionState struct {

--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitly/oauth2_proxy/cookie"
+	"../cookie"
 	"github.com/bmizerany/assert"
 )
 

--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"../cookie"
+	"github.com/articulate/oauth2_proxy/cookie"
 	"github.com/bmizerany/assert"
 )
 


### PR DESCRIPTION
hopefully add the option to use ENV variables for `redirect_url` and `upstream` so we can pass them into the container instead of having them in a cfg file. 