### PR TITLE
Oversize Cookie Alert

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -255,6 +255,10 @@ func (p *OAuthProxy) MakeCookie(req *http.Request, value string, expiration time
 
 	if value != "" {
 		value = cookie.SignedValue(p.CookieSeed, p.CookieName, value, now)
+		if len(value) > 4096 {
+			// Cookies cannot be larger than 4kb
+			log.Printf("WARNING - Cookie Size: %d bytes", len(value))
+		}
 	}
 	return &http.Cookie{
 		Name:     p.CookieName,


### PR DESCRIPTION
Cookies cannot be larger than 4kb

It took me a long while to debug this, no one else should ever have to.

This issue showed face whilst attempting to add `refresh_token` support to the Azure provider, which uses pretty large tokens.

With all the padding and what not, I was hitting 4264 bytes, which was simply triggering the alert:
`Cookie "oauth2_proxy" not present`