### PR TITLE
dist.sh: add .exe for windows build

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -20,9 +20,13 @@ echo "... running tests"
 
 for os in windows linux darwin; do
     echo "... building v$version for $os/$arch"
+    EXT=
+    if [ $os = windows ]; then
+        EXT=".exe"
+    fi
     BUILD=$(mktemp -d ${TMPDIR:-/tmp}/oauth2_proxy.XXXXXX)
     TARGET="oauth2_proxy-$version.$os-$arch.$goversion"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/oauth2_proxy || exit 1
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/oauth2_proxy$EXT || exit 1
     pushd $BUILD
     tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist


### PR DESCRIPTION
fixes #353 

```
oauth2_proxy]$ tar -tvf dist/oauth2_proxy-2.2.0-alpha.windows-amd64.go1.8.tar.gz 
drwxr-xr-x  0 pierce staff       0 Mar 27 14:43 oauth2_proxy-2.2.0-alpha.windows-amd64.go1.8/
-rwxr-xr-x  0 pierce staff 12162048 Mar 27 14:43 oauth2_proxy-2.2.0-alpha.windows-amd64.go1.8/oauth2_proxy.exe
```

cc @Esfera5