### PR TITLE
dist.sh and Godeps updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: go
 go:
-  - 1.5.4
-  - 1.6.3
+  - 1.6.4
+  - 1.7.5
+  - 1.8
 script:
-  - curl -s https://raw.githubusercontent.com/pote/gpm/v1.3.2/bin/gpm > gpm
+  - curl -s https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm > gpm
   - chmod +x gpm
   - ./gpm install
   - ./test.sh
 sudo: false
 notifications:
   email: false
-

--- a/Godeps
+++ b/Godeps
@@ -5,5 +5,5 @@ github.com/mreiferson/go-options         33795234b6f327f1be2d78a541893012362a4e0
 github.com/bmizerany/assert              e17e99893cb6509f428e1728281c2ad60a6b31e3
 gopkg.in/fsnotify.v1                     v1.2.0
 golang.org/x/oauth2                      04e1573abc896e70388bd387a69753c378d46466
-golang.org/x/oauth2/google               04e1573abc896e70388bd387a69753c378d46466
 google.golang.org/api/admin/directory/v1 a5c3e2a4792aff40e59840d9ecdff0542a202a80
+cloud.google.com/go/compute/metadata     v0.7.0

--- a/dist.sh
+++ b/dist.sh
@@ -7,7 +7,7 @@ echo "working dir $DIR"
 mkdir -p $DIR/dist
 mkdir -p $DIR/.godeps
 export GOPATH=$DIR/.godeps:$GOPATH
-gpm install
+GOPATH=$DIR/.godeps gpm install
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)

--- a/dist.sh
+++ b/dist.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-
 # build binary distributions for linux/amd64 and darwin/amd64
-set -e 
+set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "working dir $DIR"
@@ -16,7 +15,7 @@ version=$(cat $DIR/version.go | grep "const VERSION" | awk '{print $NF}' | sed '
 goversion=$(go version | awk '{print $3}')
 
 echo "... running tests"
-./test.sh || exit 1
+./test.sh
 
 for os in windows linux darwin; do
     echo "... building v$version for $os/$arch"


### PR DESCRIPTION
I ran into some problems running dist.sh on my system (OS X 10.11, go-1.8, gpm-1.4.0, git-2.12.1).

```
>> Setting github.com/18F/hmacauth to version 1.0.1
/usr/local/bin/gpm: line 73: cd: /Users/pierce/scratch/oauth2_proxy/.godeps/src/github.com/18F/hmacauth: No such file or directory
>> Setting github.com/BurntSushi/toml to version 3883ac1ce943878302255f538fce319d23226223
/usr/local/bin/gpm: line 73: cd: /Users/pierce/scratch/oauth2_proxy/.godeps/src/github.com
 (... repeated for all deps, not a showstopper, build succeeds)
```

```
>> Setting golang.org/x/oauth2 to version 04e1573abc896e70388bd387a69753c378d46466
>> Setting golang.org/x/oauth2/google to version 04e1573abc896e70388bd387a69753c378d46466
>> Setting google.golang.org/api/admin/directory/v1 to version a5c3e2a4792aff40e59840d9ecdff0542a202a80
fatal: Unable to create '/Users/pierce/scratch/oauth2_proxy/.godeps/src/golang.org/x/oauth2/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```

```
>> Getting package golang.org/x/oauth2
>> Getting package golang.org/x/oauth2/google
>> Getting package google.golang.org/api/admin/directory/v1
# cd .; git clone https://go.googlesource.com/oauth2 /Users/pierce/scratch/oauth2_proxy/.godeps/src/golang.org/x/oauth2
Cloning into '/Users/pierce/scratch/oauth2_proxy/.godeps/src/golang.org/x/oauth2'...
error: Untracked working tree file '.travis.yml' would be overwritten by merge.
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'

package golang.org/x/oauth2: exit status 128
```

```
.godeps/src/golang.org/x/oauth2/google/default.go:17:2: cannot find package "cloud.google.com/go/compute/metadata" in any of:
	/usr/local/Cellar/go/1.8/libexec/src/cloud.google.com/go/compute/metadata (from $GOROOT)
	/Users/pierce/scratch/oauth2_proxy/.godeps/src/cloud.google.com/go/compute/metadata (from $GOPATH)
	/Users/pierce/go/src/cloud.google.com/go/compute/metadata
```

With the commits in this PR, `dist.sh` runs cleanly for me (except the test "TestRequestSignaturePostRequest" fails with a sha1 signature mismatch but I'm guessing that's unrelated). Apologies if these problems are caused by my system/setup somehow.