### PR TITLE
Perform recursive lookups for group members that are themselves groups

### DIFF
--- a/providers/google.go
+++ b/providers/google.go
@@ -194,7 +194,10 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 	id := user.Id
 	custID := user.CustomerId
 
-	for _, group := range groups {
+	groups = groups[:]
+	for i := 0; i < len(groups); i++ {
+		group := groups[i]
+
 		members, err := fetchGroupMembers(service, group)
 		if err != nil {
 			log.Printf("error fetching group members: %v", err)
@@ -211,7 +214,20 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 				if member.Id == id {
 					return true
 				}
+			case "GROUP":
+				if !containsString(groups, member.Email) {
+					groups = append(groups, member.Email)
+				}
 			}
+		}
+	}
+	return false
+}
+
+func containsString(elems []string, s string) bool {
+	for _, e := range elems {
+		if e == s {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
In Google groups it is possible to make groups members of other groups. If A is
a member of group G and group G is a member of group H, then A should also be
considered a member of group H.

This change will append any groups found when listing group members to the
array of groups to iterate through, so that eventually all top-level and nested
groups will be used to check membership for the user. It is not clear whether
cyclic group membership is permitted by Google but it is being checked for just
in case.