### PR TITLE
Option to skip SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Usage of oauth2_proxy:
   -signature-key="": GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-regex=: bypass authentication for requests path's that match (may be given multiple times)
   -skip-provider-button=false: will skip sign-in-page to directly reach the next step: oauth/start
+  -ssl-insecure-skip-verify: skip validation of certificates presented when using HTTPS
   -tls-cert="": path to certificate file
   -tls-key="": path to private key file
   -upstream=: the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -54,6 +54,10 @@
 ## optional directory with custom sign_in.html and error.html
 # custom_templates_dir = ""
 
+## skip SSL checking for HTTPS requests
+# ssl_insecure_skip_verify = false
+
+
 ## Cookie Settings
 ## Name     - the cookie name
 ## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
+	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")


### PR DESCRIPTION
This adds an option to skip SSL verification which is useful when using oauth2_proxy in a development environment, or against a provider with a self-signed certificate.

This fixes #350, #234