### PR TITLE
Add Let's Encrypt Support

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -4,6 +4,7 @@ github.com/bitly/go-simplejson           da1a8928f709389522c8023062a3739f3b4af41
 github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d
 github.com/bmizerany/assert              e17e99893cb6509f428e1728281c2ad60a6b31e3
 gopkg.in/fsnotify.v1                     v1.2.0
+golang.org/x/crypto                      c2303dcbe84172e0c0da4c9f083eeca54c06f298
 golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
 google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877

--- a/Godeps
+++ b/Godeps
@@ -4,7 +4,7 @@ github.com/bitly/go-simplejson           da1a8928f709389522c8023062a3739f3b4af41
 github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d
 github.com/bmizerany/assert              e17e99893cb6509f428e1728281c2ad60a6b31e3
 gopkg.in/fsnotify.v1                     v1.2.0
-golang.org/x/crypto                      c2303dcbe84172e0c0da4c9f083eeca54c06f298
+golang.org/x/crypto/acme                 c2303dcbe84172e0c0da4c9f083eeca54c06f298
 golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
 google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877

--- a/http.go
+++ b/http.go
@@ -15,8 +15,6 @@ import (
 type Server struct {
 	Handler http.Handler
 	Opts    *Options
-
-	m *letsencrypt.Manager
 }
 
 func (s *Server) ListenAndServe() {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
+	letsEncryptHosts := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -30,10 +31,10 @@ func main() {
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 
-	flagSet.Bool("letsencrypt-enabled", false, "use letsencrypt")
-	flagSet.String("letsencrypt-cache-dir", "./", "letsencrypt certificate cache directory")
-	flagSet.String("letsencrypt-admin-email", "", "letsencrypt admin email")
-	flagSet.String("letsencrypt-domain", "", "domain to secure with letsencrypt")
+	flagSet.Bool("letsencrypt-enabled", false, "use Let's Encrypt ACME certificates")
+	flagSet.String("letsencrypt-admin-email", "", "Admin contact email; sent to Let's Encrypt during registration during registration")
+	flagSet.Var(&letsEncryptHosts, "letsencrypt-host", "Obtain TLS certificates for this domain with Let's Encrypt (may be given multiple times)")
+	flagSet.String("letsencrypt-cache-dir", "./", "Let's Encrypt certificate cache directory")
 
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")

--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ func main() {
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
+
+	flagSet.Bool("letsencrypt-enabled", false, "use letsencrypt")
+	flagSet.String("letsencrypt-cache-dir", "./", "letsencrypt certificate cache directory")
+	flagSet.String("letsencrypt-admin-email", "", "letsencrypt admin email")
+	flagSet.String("letsencrypt-domain", "", "domain to secure with letsencrypt")
+
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")

--- a/options.go
+++ b/options.go
@@ -27,9 +27,10 @@ type Options struct {
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
-	LetsEncryptEnabled    bool   `flag:"letsencrypt-enabled" cfg:"letsencrypt-enabled"`
-	LetsEncryptCacheDir   string `flag:"letsencrypt-cache-dir" cfg:"letsencrypt-cache-dir"`
-	LetsEncryptAdminEmail string `flag:"letsencrypt-admin-email" cfg:"letsencrypt-admin-email"`
+	LetsEncryptEnabled    bool     `flag:"letsencrypt-enabled" cfg:"letsencrypt_enabled"`
+	LetsEncryptHosts      []string `flag:"letsencrypt-host" cfg:"letsencrypt_hosts"`
+	LetsEncryptCacheDir   string   `flag:"letsencrypt-cache-dir" cfg:"letsencrypt_cache_dir"`
+	LetsEncryptAdminEmail string   `flag:"letsencrypt-admin-email" cfg:"letsencrypt_admin_email"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
@@ -109,6 +110,7 @@ func NewOptions() *Options {
 		PassHostHeader:      true,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
+		LetsEncryptCacheDir: "./",
 	}
 }
 
@@ -145,6 +147,14 @@ func (o *Options) Validate() error {
 
 	if o.LetsEncryptEnabled && o.LetsEncryptAdminEmail == "" {
 		msgs = append(msgs, "must set letsencrypt-admin-email if letsencrypt is enabled")
+	}
+
+	if o.LetsEncryptEnabled && o.LetsEncryptCacheDir == "" {
+		msgs = append(msgs, "must set letsencrypt-cache-dir if letsencrypt is enabled")
+	}
+
+	if o.LetsEncryptEnabled && len(o.LetsEncryptHosts) == 0 {
+		msgs = append(msgs, "must provide at least one letsencrypt-host if letsencrypt is enabled")
 	}
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)

--- a/options.go
+++ b/options.go
@@ -27,6 +27,10 @@ type Options struct {
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
+	LetsEncryptEnabled    bool   `flag:"letsencrypt-enabled" cfg:"letsencrypt-enabled"`
+	LetsEncryptCacheDir   string `flag:"letsencrypt-cache-dir" cfg:"letsencrypt-cache-dir"`
+	LetsEncryptAdminEmail string `flag:"letsencrypt-admin-email" cfg:"letsencrypt-admin-email"`
+
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
@@ -133,6 +137,14 @@ func (o *Options) Validate() error {
 	}
 	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
 		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+	}
+
+	if o.LetsEncryptEnabled && (o.TLSCertFile != "" || o.TLSKeyFile != "") {
+		msgs = append(msgs, "cannot enable letsencrypt AND specify a TLS keypair")
+	}
+
+	if o.LetsEncryptEnabled && o.LetsEncryptAdminEmail == "" {
+		msgs = append(msgs, "must set letsencrypt-admin-email if letsencrypt is enabled")
 	}
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)

--- a/options_test.go
+++ b/options_test.go
@@ -58,12 +58,16 @@ func TestLetsEncryptOptions(t *testing.T) {
 	o := testOptions()
 	o.LetsEncryptEnabled = true
 	o.TLSCertFile = "key.keyfile"
+	o.LetsEncryptCacheDir = ""
 	err := o.Validate()
 	assert.NotEqual(t, nil, err)
 
 	expected := errorMsg([]string{
 		"cannot enable letsencrypt AND specify a TLS keypair",
-		"must set letsencrypt-admin-email if letsencrypt is enabled"})
+		"must set letsencrypt-admin-email if letsencrypt is enabled",
+		"must set letsencrypt-cache-dir if letsencrypt is enabled",
+		"must provide at least one letsencrypt-host if letsencrypt is enabled",
+	})
 	assert.Equal(t, expected, err.Error())
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -54,6 +54,19 @@ func TestGoogleGroupOptions(t *testing.T) {
 	assert.Equal(t, expected, err.Error())
 }
 
+func TestLetsEncryptOptions(t *testing.T) {
+	o := testOptions()
+	o.LetsEncryptEnabled = true
+	o.TLSCertFile = "key.keyfile"
+	err := o.Validate()
+	assert.NotEqual(t, nil, err)
+
+	expected := errorMsg([]string{
+		"cannot enable letsencrypt AND specify a TLS keypair",
+		"must set letsencrypt-admin-email if letsencrypt is enabled"})
+	assert.Equal(t, expected, err.Error())
+}
+
 func TestGoogleGroupInvalidFile(t *testing.T) {
 	o := testOptions()
 	o.GoogleGroups = []string{"test_group"}


### PR DESCRIPTION
Build on @fortytw2's work and add Let's Encrypt TLS certificate support. This PR replaces PR #314 and addresses #313.

- Switched to use golang.org/x/crypto/acme/autocert
- Added more options tests.
- Added documentation in README and CLI prompts.
- Tested and running as expected in my production environment.


_I couldn't figure out a way to append to that existing PR so I created a new one._
_Sorry if this isn't the right way to do it._