### PR TITLE
Refactor proxy director functions

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -60,7 +60,6 @@ func TestEncodedSlashes(t *testing.T) {
 
 	b, _ := url.Parse(backend.URL)
 	proxyHandler := NewReverseProxy(b)
-	setProxyDirector(proxyHandler)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
 


### PR DESCRIPTION
I noticed that these two proxy director functions do the same thing in terms of manipulating the request URL. Rather than have the code in both director functions, I moved it to the `Proxy` function where it will always run. Now the code only uses the custom director to pass the `Host`.

I wanted the ability to update this director code a bit, i.e. allow a couple more options in terms of manipulating the request. Maintaining both functions makes this a bit more cumbersome, hence the refactor.