### PR TITLE
dist.sh: use go build option to strip binaries

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -25,7 +25,8 @@ for os in windows linux darwin; do
     fi
     BUILD=$(mktemp -d ${TMPDIR:-/tmp}/oauth2_proxy.XXXXXX)
     TARGET="oauth2_proxy-$version.$os-$arch.$goversion"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/oauth2_proxy$EXT || exit 1
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
+        go build -ldflags="-s -w" -o $BUILD/$TARGET/oauth2_proxy$EXT || exit 1
     pushd $BUILD
     tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.2.0"
+const VERSION = "2.2.1-alpha"


### PR DESCRIPTION
30% release binary size reduction - from 10487848 bytes to 7041472 bytes for the linux x86_64 build.

I also bumped the version for dev, I can rebase and omit that commit if a different version bump is done in master.