### PR TITLE
On failure, avoid immediately panic via nil pointer deref

### DIFF
--- a/options.go
+++ b/options.go
@@ -145,6 +145,7 @@ func (o *Options) Validate() error {
 			msgs = append(msgs, fmt.Sprintf(
 				"error parsing upstream=%q %s",
 				upstreamURL, err))
+			continue
 		}
 		if upstreamURL.Path == "" {
 			upstreamURL.Path = "/"
@@ -157,6 +158,7 @@ func (o *Options) Validate() error {
 		if err != nil {
 			msgs = append(msgs, fmt.Sprintf(
 				"error compiling regex=%q %s", u, err))
+			continue
 		}
 		o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
 	}


### PR DESCRIPTION
Bad command line config currently panics.  This clearly isn't intended, so short-circuit the panic and let the existing configuration error code handle the error.