### PR TITLE
Update Google Auth Provider instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For Google, the registration steps are:
 
 1. Create a new project: https://console.developers.google.com/project
 2. Choose the new project from the top right project dropdown (only if another project is selected)
-3. In the project Dashboard center pane, choose **"Enable and manage APIs"**
+3. In the project Dashboard center pane, choose **"API Manager"**
 4. In the left Nav pane, choose **"Credentials"**
 5. In the center pane, choose **"OAuth consent screen"** tab. Fill in **"Product name shown to users"** and hit save.
 6. In the center pane, choose **"Credentials"** tab.


### PR DESCRIPTION
"Enable and manage APIs" is now called "API Manager"