### PR TITLE
Inspect X-Original-URI header and allow internal URLs

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -594,6 +594,19 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int {
+	// if any of the internal urls necessary for the oauth2 flow is called, allow the request
+	// This is necessary to use oauth2_proxy as auth_request server for nginx based k8s ingresses
+	originalRequestUri := req.Header.Get("X-Original-URI")
+	for _, allowedUrl := range []string{
+		p.SignInPath,
+		p.SignOutPath,
+		p.OAuthCallbackPath,
+		p.OAuthStartPath,
+	} {
+		if strings.HasPrefix(originalRequestUri, allowedUrl) {
+			return http.StatusAccepted
+		}
+	}
 	var saveSession, clearSession, revalidated bool
 	remoteAddr := getRemoteAddr(req)
 


### PR DESCRIPTION
This PR helps with #411. If you send your original request uri via the header `X-Original-URI` it will be taken into consideration when authenticating the request. This makes it easier to use oauth2_proxy as auth_request service with nginx. For example the nginx based ingress for kubernetes doesn't allow you to enforce authentication only for selected locations, so oauth2_proxy needs to allow the oauth2 callback urls etc.
Here is an example ingress config for use with oauth2_proxy
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: internal-ingress
  annotations:
    ingress.kubernetes.io/auth-url: "http://oauth2-proxy.default.svc.cluster.local:8080/oauth2/auth"
    ingress.kubernetes.io/auth-method: "GET"
    ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User, X-Auth-Request-Email
    ingress.kubernetes.io/configuration-snippet: |
      add_header Set-Cookie $auth_cookie;
      auth_request_set $auth_cookie $upstream_http_set_cookie;
      auth_request_set $user   $upstream_http_x_auth_request_user;
      auth_request_set $email  $upstream_http_x_auth_request_email;
      proxy_set_header X-User  $user;
      proxy_set_header X-Email $email;
      error_page 401 /oauth2/sign_in;

    kubernetes.io/ingress.class: "nginx"
    ingress.kubernetes.io/force-ssl-redirect: "true"
    ingress.kubernetes.io/ssl-redirect: "true"
spec:
...
```