### PR TITLE
Make Request Logging Format Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Usage of oauth2_proxy:
   -redeem-url string: Token redemption endpoint
   -redirect-url string: the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
   -request-logging: Log requests to stdout (default true)
+  -request-logging-format: Template for request log lines (see "Logging Format" paragraph below)
   -resource string: The resource that is protected (Azure AD only)
   -scope string: OAuth scope specification
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
@@ -331,11 +332,20 @@ following:
 
 ## Logging Format
 
-OAuth2 Proxy logs requests to stdout in a format similar to Apache Combined Log.
+By default, OAuth2 Proxy logs requests to stdout in a format similar to Apache Combined Log.
 
 ```
 <REMOTE_ADDRESS> - <user@domain.com> [19/Mar/2015:17:20:19 -0400] <HOST_HEADER> GET <UPSTREAM_HOST> "/path/" HTTP/1.1 "<USER_AGENT>" <RESPONSE_CODE> <RESPONSE_BYTES> <REQUEST_DURATION>
 ```
+
+If you require a different format than that, you can configure it with the `-request-logging-format` flag.
+The default format is configured as follows:
+
+```
+{{.Client}} - {{.Username}} [{{.Timestamp}}] {{.Host}} {{.RequestMethod}} {{.Upstream}} {{.RequestURI}} {{.Protocol}} {{.UserAgent}} {{.StatusCode}} {{.ResponseSize}} {{.RequestDuration}}
+```
+
+[See `logMessageData` in `logging_handler.go`](./logging_handler.go) for all available variables.
 
 ## Adding a new Provider
 

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestLoggingHandler_ServeHTTP(t *testing.T) {
+	ts := time.Now()
+
+	tests := []struct {
+		Format,
+		ExpectedLogMessage string
+	}{
+		{defaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", ts.Format("02/Jan/2006:15:04:05 -0700"))},
+		{"{{.RequestMethod}}", "GET\n"},
+	}
+
+	for _, test := range tests {
+		buf := bytes.NewBuffer(nil)
+		handler := func(w http.ResponseWriter, req *http.Request) {
+			w.Write([]byte("test"))
+		}
+
+		h := LoggingHandler(buf, http.HandlerFunc(handler), true, test.Format)
+
+		r, _ := http.NewRequest("GET", "/foo/bar", nil)
+		r.RemoteAddr = "127.0.0.1"
+		r.Host = "test-server"
+
+		h.ServeHTTP(httptest.NewRecorder(), r)
+
+		actual := buf.String()
+		if actual != test.ExpectedLogMessage {
+			t.Errorf("Log message was\n%s\ninstead of expected \n%s", actual, test.ExpectedLogMessage)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
+	flagSet.String("request-logging-format", defaultRequestLoggingFormat, "Template for log lines")
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("login-url", "", "Authentication endpoint")
@@ -124,7 +125,7 @@ func main() {
 	}
 
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging),
+		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat),
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/options.go
+++ b/options.go
@@ -71,7 +71,8 @@ type Options struct {
 	Scope             string `flag:"scope" cfg:"scope"`
 	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt"`
 
-	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
+	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging"`
+	RequestLoggingFormat string `flag:"request-logging-format" cfg:"request_logging_format"`
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
@@ -90,23 +91,24 @@ type SignatureData struct {
 
 func NewOptions() *Options {
 	return &Options{
-		ProxyPrefix:         "/oauth2",
-		HttpAddress:         "127.0.0.1:4180",
-		HttpsAddress:        ":443",
-		DisplayHtpasswdForm: true,
-		CookieName:          "_oauth2_proxy",
-		CookieSecure:        true,
-		CookieHttpOnly:      true,
-		CookieExpire:        time.Duration(168) * time.Hour,
-		CookieRefresh:       time.Duration(0),
-		SetXAuthRequest:     false,
-		SkipAuthPreflight:   false,
-		PassBasicAuth:       true,
-		PassUserHeaders:     true,
-		PassAccessToken:     false,
-		PassHostHeader:      true,
-		ApprovalPrompt:      "force",
-		RequestLogging:      true,
+		ProxyPrefix:          "/oauth2",
+		HttpAddress:          "127.0.0.1:4180",
+		HttpsAddress:         ":443",
+		DisplayHtpasswdForm:  true,
+		CookieName:           "_oauth2_proxy",
+		CookieSecure:         true,
+		CookieHttpOnly:       true,
+		CookieExpire:         time.Duration(168) * time.Hour,
+		CookieRefresh:        time.Duration(0),
+		SetXAuthRequest:      false,
+		SkipAuthPreflight:    false,
+		PassBasicAuth:        true,
+		PassUserHeaders:      true,
+		PassAccessToken:      false,
+		PassHostHeader:       true,
+		ApprovalPrompt:       "force",
+		RequestLogging:       true,
+		RequestLoggingFormat: defaultRequestLoggingFormat,
 	}
 }
 


### PR DESCRIPTION
We want to analyze access logs of the oauth2 proxy in our centralized logging system where we use a slightly different access log format.

This PR makes the request logging format configurable via a template string passed as `-request-logging-format`. The default format stays the same of course.