### PR TITLE
Access token forwarding through nginx auth request

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,10 @@ server {
     # requires running with --set-xauthrequest flag
     auth_request_set $user   $upstream_http_x_auth_request_user;
     auth_request_set $email  $upstream_http_x_auth_request_email;
+    auth_request_set $token  $upstream_http_x_auth_request_access_token;  # Available with --pass-access-token flag
     proxy_set_header X-User  $user;
     proxy_set_header X-Email $email;
+    proxy_set_header X-Token $token;
 
     # if you enabled --cookie-refresh, this is needed for it to work with auth_request
     auth_request_set $auth_cookie $upstream_http_set_cookie;

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -680,6 +680,9 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		if session.Email != "" {
 			rw.Header().Set("X-Auth-Request-Email", session.Email)
 		}
+		if p.PassAccessToken && session.AccessToken != "" {
+			rw.Header().Set("X-Auth-Request-Access-Token", session.AccessToken)
+		}
 	}
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}


### PR DESCRIPTION
Related to #420.

This enables expected behavior when using:

```
set_xauthrequest = true
pass_access_token = true
```

If both of these are set, the access token will be included in an `X-Auth-Request-Access-Token` header, following the `X-Auth-Request-*` pattern used for `User` and `Email`.

The access token allows for further validation by upstream services. In my case, I use the token to get more user information, which is then used to set read-only / read-write / admin permissions on internal software.