### PR TITLE
Update cookie generation to match base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To authorize by email domain use `--email-domain=yourcompany.com`. To authorize 
 
 `oauth2_proxy` can be configured via [config file](#config-file), [command line options](#command-line-options) or [environment variables](#environment-variables).
 
-To generate a strong cookie secret use `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'`
+To generate a strong cookie secret use `python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'`
 
 ### Config File
 


### PR DESCRIPTION
Current code is using URLEncoding but example was using the
standard RFC 4648 encoding. Switch to using the URL
encoding in the example as well.