### PR TITLE
Remove check for >0 upstreams

### DIFF
--- a/options.go
+++ b/options.go
@@ -121,9 +121,6 @@ func parseURL(to_parse string, urltype string, msgs []string) (*url.URL, []strin
 
 func (o *Options) Validate() error {
 	msgs := make([]string, 0)
-	if len(o.Upstreams) < 1 {
-		msgs = append(msgs, "missing setting: upstream")
-	}
 	if o.CookieSecret == "" {
 		msgs = append(msgs, "missing setting: cookie-secret")
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -35,7 +35,6 @@ func TestNewOptions(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 
 	expected := errorMsg([]string{
-		"missing setting: upstream",
 		"missing setting: cookie-secret",
 		"missing setting: client-id",
 		"missing setting: client-secret"})


### PR DESCRIPTION
When used solely for auth_request there is no upstream.
Instead of forcing users to set a dummy upstream, remove
the check.