### PR TITLE
Allow redirect URL to be passed in the query string.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -368,6 +368,9 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	if req.Header.Get("X-Auth-Request-Redirect") != "" {
 		redirect_url = req.Header.Get("X-Auth-Request-Redirect")
 	}
+	if rd, ok := req.URL.Query()["rd"]; ok {
+		redirect_url = rd[0]
+	}
 	if redirect_url == p.SignInPath {
 		redirect_url = "/"
 	}


### PR DESCRIPTION
When using the Kubernetes nginx ingress controller, the sign_in page is reached via a 302 redirect, which means that we cannot use the `X-Auth-Request-Redirect` header. Instead, we need to be able to include the URL in the query string.