### PR TITLE
gracefully report un-parsed upstream URL

### DIFF
--- a/options.go
+++ b/options.go
@@ -142,14 +142,13 @@ func (o *Options) Validate() error {
 	for _, u := range o.Upstreams {
 		upstreamURL, err := url.Parse(u)
 		if err != nil {
-			msgs = append(msgs, fmt.Sprintf(
-				"error parsing upstream=%q %s",
-				upstreamURL, err))
+			msgs = append(msgs, fmt.Sprintf("error parsing upstream: %s", err))
+		} else {
+			if upstreamURL.Path == "" {
+				upstreamURL.Path = "/"
+			}
+			o.proxyURLs = append(o.proxyURLs, upstreamURL)
 		}
-		if upstreamURL.Path == "" {
-			upstreamURL.Path = "/"
-		}
-		o.proxyURLs = append(o.proxyURLs, upstreamURL)
 	}
 
 	for _, u := range o.SkipAuthRegex {

--- a/options.go
+++ b/options.go
@@ -134,7 +134,8 @@ func (o *Options) Validate() error {
 		msgs = append(msgs, "missing setting: client-secret")
 	}
 	if o.AuthenticatedEmailsFile == "" && len(o.EmailDomains) == 0 && o.HtpasswdFile == "" {
-		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
+		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required."+
+			"\n      use email-domain=* to authorize all email addresses")
 	}
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)


### PR DESCRIPTION
fixes #430 

Current master branch:

```
$ ./oauth2_proxy --upstream=127.0.0.1:8080
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x13b8d2f]

goroutine 1 [running]:
main.(*Options).Validate(0xc4200f8000, 0xc4200f8000, 0xc420012480)
	/Users/pierce/go/src/github.com/bitly/oauth2_proxy/options.go:149 +0x30f
main.main()
	/Users/pierce/go/src/github.com/bitly/oauth2_proxy/main.go:101 +0x1303
```

This branch:

```
$ ./oauth2_proxy --upstream=127.0.0.1:8080
2017/08/05 13:17:42 main.go:103: Invalid configuration:
  missing setting: cookie-secret
  missing setting: client-id
  missing setting: client-secret
  missing setting for email validation: email-domain or authenticated-emails-file required.
      use email-domain=* to authorize all email addresses
  error parsing upstream: parse 127.0.0.1:8080: first path segment in URL cannot contain colon
```

cc @tpherndon 