### PR TITLE
Use read_user as default scope for GitLab

### DIFF
--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -36,7 +36,7 @@ func NewGitLabProvider(p *ProviderData) *GitLabProvider {
 		}
 	}
 	if p.Scope == "" {
-		p.Scope = "api"
+		p.Scope = "read_user"
 	}
 	return &GitLabProvider{ProviderData: p}
 }

--- a/providers/gitlab_test.go
+++ b/providers/gitlab_test.go
@@ -53,7 +53,7 @@ func TestGitLabProviderDefaults(t *testing.T) {
 		p.Data().RedeemURL.String())
 	assert.Equal(t, "https://gitlab.com/api/v3/user",
 		p.Data().ValidateURL.String())
-	assert.Equal(t, "api", p.Data().Scope)
+	assert.Equal(t, "read_user", p.Data().Scope)
 }
 
 func TestGitLabProviderOverrides(t *testing.T) {


### PR DESCRIPTION
"read_user" works as a default scope for GitLab. The previous "api" scope gives full API access AFAIK?