### PR TITLE
Switch from 18F/hmacauth to mbland/hmacauth

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,4 +1,4 @@
-github.com/18F/hmacauth                  1.0.1
+github.com/mbland/hmacauth               1.0.2
 github.com/BurntSushi/toml               d94612f9fc140360834f9742158c70b5c5b5535b
 github.com/bitly/go-simplejson           da1a8928f709389522c8023062a3739f3b4af419
 github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/18F/hmacauth"
 	"github.com/bitly/oauth2_proxy/cookie"
 	"github.com/bitly/oauth2_proxy/providers"
+	"github.com/mbland/hmacauth"
 )
 
 const SignatureHeader = "GAP-Signature"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/18F/hmacauth"
 	"github.com/bitly/oauth2_proxy/providers"
+	"github.com/mbland/hmacauth"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/options.go
+++ b/options.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/18F/hmacauth"
 	"github.com/bitly/oauth2_proxy/providers"
 	oidc "github.com/coreos/go-oidc"
+	"github.com/mbland/hmacauth"
 )
 
 // Configuration Options that can be set by Command Line Flag, or Config File


### PR DESCRIPTION
Since I'm no longer with 18F, I've re-released hmacauth under the ISC license as opposed to the previous CC0 license. There have been no changes to the hmacauth code itself, and all tests still pass.