### PR TITLE
Add support for Basic HTTP for Redeem() on a per-provider basis

### DIFF
--- a/options.go
+++ b/options.go
@@ -244,6 +244,7 @@ func (o *Options) Validate() error {
 
 func parseProviderInfo(o *Options, msgs []string) []string {
 	p := &providers.ProviderData{
+		HTTPBasicAuth:  false,
 		Scope:          o.Scope,
 		ClientID:       o.ClientID,
 		ClientSecret:   o.ClientSecret,

--- a/providers/common_test.go
+++ b/providers/common_test.go
@@ -1,0 +1,37 @@
+package providers
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+type redeemResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	IdToken      string `json:"id_token"`
+}
+
+func newRedeemServer(body []byte) (*url.URL, *httptest.Server, map[string]interface{}) {
+	req := make(map[string]interface{})
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if req != nil {
+			buf, _ := ioutil.ReadAll(r.Body)
+			rdr := ioutil.NopCloser(bytes.NewBuffer(buf))
+
+			r.Body = rdr // OK since rdr2 implements the io.ReadCloser interface
+
+			req["body"] = buf
+			req["header"] = r.Header
+			username, password, _ := r.BasicAuth()
+			req["username"] = username
+			req["password"] = password
+		}
+		rw.Write(body)
+	}))
+	u, _ := url.Parse(s.URL)
+	return u, s, req
+}

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -3,21 +3,12 @@ package providers
 import (
 	"encoding/base64"
 	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/bmizerany/assert"
 )
-
-func newRedeemServer(body []byte) (*url.URL, *httptest.Server) {
-	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		rw.Write(body)
-	}))
-	u, _ := url.Parse(s.URL)
-	return u, s
-}
 
 func newGoogleProvider() *GoogleProvider {
 	return NewGoogleProvider(
@@ -77,13 +68,6 @@ func TestGoogleProviderOverrides(t *testing.T) {
 	assert.Equal(t, "profile", p.Data().Scope)
 }
 
-type redeemResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int64  `json:"expires_in"`
-	IdToken      string `json:"id_token"`
-}
-
 func TestGoogleProviderGetEmailAddress(t *testing.T) {
 	p := newGoogleProvider()
 	body, err := json.Marshal(redeemResponse{
@@ -94,7 +78,7 @@ func TestGoogleProviderGetEmailAddress(t *testing.T) {
 	})
 	assert.Equal(t, nil, err)
 	var server *httptest.Server
-	p.RedeemURL, server = newRedeemServer(body)
+	p.RedeemURL, server, _ = newRedeemServer(body)
 	defer server.Close()
 
 	session, err := p.Redeem("http://redirect/", "code1234")
@@ -131,7 +115,7 @@ func TestGoogleProviderGetEmailAddressInvalidEncoding(t *testing.T) {
 	})
 	assert.Equal(t, nil, err)
 	var server *httptest.Server
-	p.RedeemURL, server = newRedeemServer(body)
+	p.RedeemURL, server, _ = newRedeemServer(body)
 	defer server.Close()
 
 	session, err := p.Redeem("http://redirect/", "code1234")
@@ -150,7 +134,7 @@ func TestGoogleProviderGetEmailAddressInvalidJson(t *testing.T) {
 	})
 	assert.Equal(t, nil, err)
 	var server *httptest.Server
-	p.RedeemURL, server = newRedeemServer(body)
+	p.RedeemURL, server, _ = newRedeemServer(body)
 	defer server.Close()
 
 	session, err := p.Redeem("http://redirect/", "code1234")
@@ -169,7 +153,7 @@ func TestGoogleProviderGetEmailAddressEmailMissing(t *testing.T) {
 	})
 	assert.Equal(t, nil, err)
 	var server *httptest.Server
-	p.RedeemURL, server = newRedeemServer(body)
+	p.RedeemURL, server, _ = newRedeemServer(body)
 	defer server.Close()
 
 	session, err := p.Redeem("http://redirect/", "code1234")

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,6 +5,7 @@ import (
 )
 
 type ProviderData struct {
+	HTTPBasicAuth     bool
 	ProviderName      string
 	ClientID          string
 	ClientSecret      string

--- a/providers/provider_default_test.go
+++ b/providers/provider_default_test.go
@@ -1,6 +1,10 @@
 package providers
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -15,3 +19,82 @@ func TestRefresh(t *testing.T) {
 	assert.Equal(t, false, refreshed)
 	assert.Equal(t, nil, err)
 }
+
+func TestDefaultProviderRedeem(t *testing.T) {
+	clientID, clientSecret, scope := "abc", "def", "profile"
+	loginURL, redeemURL, profileURL, validateURL := &url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		Path:   "/oauth/auth",
+	}, &url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		Path:   "/oauth/token",
+	}, &url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		Path:   "/oauth/profile",
+	}, &url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		Path:   "/oauth/tokeninfo",
+	}
+
+	p := ProviderData{
+		HTTPBasicAuth:     true,
+		ProviderName:      "Tester",
+		ClientID:          clientID,
+		ClientSecret:      clientSecret,
+		LoginURL:          loginURL,
+		RedeemURL:         redeemURL,
+		ProfileURL:        profileURL,
+		ProtectedResource: nil,
+		ValidateURL:       validateURL,
+		Scope:             scope,
+		ApprovalPrompt:    "prompt",
+	}
+	body, err := json.Marshal(redeemResponse{
+		AccessToken:  "a1234",
+		ExpiresIn:    10,
+		RefreshToken: "refresh12345",
+		IdToken:      "ignored prefix." + base64.URLEncoding.EncodeToString([]byte(`{"email": "michael.bland@gsa.gov", "email_verified":true}`)),
+	})
+	assert.Equal(t, nil, err)
+	var server *httptest.Server
+	var req map[string]interface{}
+	p.RedeemURL, server, req = newRedeemServer(body)
+	defer server.Close()
+
+	t.Run("HTTPBasicAuth yes", func(t *testing.T) {
+		p.HTTPBasicAuth = true
+		_, err := p.Redeem("http://redirect/", "code1234")
+		assert.Equal(t, nil, err)
+		assert.Equal(t, p.ClientID, req["username"])
+		assert.Equal(t, p.ClientSecret, req["password"])
+
+		reqbody, err := url.ParseQuery(string(req["body"].([]byte)))
+		assert.Equal(t, nil, err)
+		assert.Equal(t, "", reqbody.Get("client_secret"))
+		assert.Equal(t, p.ClientID, reqbody.Get("client_id"))
+	})
+	t.Run("HTTPBasicAuth no", func(t *testing.T) {
+		p.HTTPBasicAuth = false
+		_, err := p.Redeem("http://redirect/", "code1234")
+		assert.Equal(t, nil, err)
+		assert.Equal(t, "", req["username"])
+		assert.Equal(t, "", req["password"])
+
+		reqbody, err := url.ParseQuery(string(req["body"].([]byte)))
+		assert.Equal(t, nil, err)
+		assert.Equal(t, p.ClientID, reqbody.Get("client_id"))
+		assert.Equal(t, p.ClientSecret, reqbody.Get("client_secret"))
+	})
+}
+
+/*
+	LEFT:
+	1- WithBasicAuth: check that did *not* set client_secret in body
+	2- WithoutBasicAuth: check that *did* set client_secret in body
+	3- WithoutBasicAuth: check that did *not* set httpbasicauth
+	4- use the multiple test wrapper
+*/


### PR DESCRIPTION
As discussed in https://github.com/bitly/oauth2_proxy/issues/450

This PR adds the ability for a provider to flag that it wants to pass `client_secret` using http basic auth, rather than in the `POST` body. According to the RFC, an implementation "MUST support the HTTP Basic authentication scheme for authenticating clients", and only "MAY support including the client credentials in the request-body". 

Once this is merged, we can test each provider and enable it by having it set `p.HTTPBasicAuth = true`. Right now, the default is `p.HTTPBasicAuth = false`. Eventually, this should be flipped (per the RFC).

Additional changes:

* adds unit tests for enabling/disabling `p.HTTPBasicAuth`
* extracts some common testing code from `providers/google_test.go` and `providers/provider_default_test.go` into `providers/common_test.go`
* adds an additional return value to `newRedeemServer()` of a `map` containing the body, headers and auth of the request, so it can be validated
