### PR TITLE
Fix Godeps version for cloud.google.com/go/compute/metadata

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -7,7 +7,7 @@ gopkg.in/fsnotify.v1                     v1.2.0
 golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
 google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877
-cloud.google.com/go/compute/metadata     v0.7.0
+cloud.google.com/go/compute/metadata     v0.8.0
 github.com/coreos/go-oidc                c797a55f1c1001ec3169f1d0fbb4c5523563bec6
 gopkg.in/square/go-jose.v2               v2.1.1
 github.com/pquerna/cachecontrol          9299cc36e57c32f83e47ffb3c25d8a3dec10ea0b

--- a/Godeps
+++ b/Godeps
@@ -11,3 +11,5 @@ cloud.google.com/go/compute/metadata     v0.8.0
 github.com/coreos/go-oidc                c797a55f1c1001ec3169f1d0fbb4c5523563bec6
 gopkg.in/square/go-jose.v2               v2.1.1
 github.com/pquerna/cachecontrol          9299cc36e57c32f83e47ffb3c25d8a3dec10ea0b
+github.com/kr/pretty                     cfb55aafdaf3ec08f0db22699ab822c50091b1c4
+github.com/kr/text                       7cafcd837844e784b526369c9bce262804aebc60

--- a/Godeps
+++ b/Godeps
@@ -7,6 +7,9 @@ gopkg.in/fsnotify.v1                     v1.2.0
 golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
 google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877
+# also used from google.golang.org/api:
+# google.golang.org/api/googleapi        <same version as above>
+# google.golang.org/api/gensupport       <same version as above>
 cloud.google.com/go/compute/metadata     v0.8.0
 github.com/coreos/go-oidc                c797a55f1c1001ec3169f1d0fbb4c5523563bec6
 gopkg.in/square/go-jose.v2               v2.1.1

--- a/Godeps
+++ b/Godeps
@@ -1,18 +1,18 @@
+cloud.google.com/go/compute/metadata     v0.8.0
 github.com/18F/hmacauth                  1.0.1
 github.com/BurntSushi/toml               d94612f9fc140360834f9742158c70b5c5b5535b
 github.com/bitly/go-simplejson           da1a8928f709389522c8023062a3739f3b4af419
-github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d
 github.com/bmizerany/assert              e17e99893cb6509f428e1728281c2ad60a6b31e3
-gopkg.in/fsnotify.v1                     v1.2.0
-golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
-golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
-google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877
-# also used from google.golang.org/api:
-# google.golang.org/api/googleapi        <same version as above>
-# google.golang.org/api/gensupport       <same version as above>
-cloud.google.com/go/compute/metadata     v0.8.0
 github.com/coreos/go-oidc                c797a55f1c1001ec3169f1d0fbb4c5523563bec6
-gopkg.in/square/go-jose.v2               v2.1.1
-github.com/pquerna/cachecontrol          9299cc36e57c32f83e47ffb3c25d8a3dec10ea0b
 github.com/kr/pretty                     cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 github.com/kr/text                       7cafcd837844e784b526369c9bce262804aebc60
+github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d
+github.com/pquerna/cachecontrol          9299cc36e57c32f83e47ffb3c25d8a3dec10ea0b
+golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
+golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
+google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877
+# also used from google.golang.org/api:
+# google.golang.org/api/gensupport       <same version as above>
+# google.golang.org/api/googleapi        <same version as above>
+gopkg.in/fsnotify.v1                     v1.2.0
+gopkg.in/square/go-jose.v2               v2.1.1


### PR DESCRIPTION
When manually checking out `v0.8.0` instead of `v0.7.0` for `cloud.google.com/go/compute/metadata`, oauth2_proxy can be compiled and successfully tested.

This fixes issue #458.
