### PR TITLE
External redirect urls

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
+	redirectDomains := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -30,6 +31,7 @@ func main() {
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.Var(&redirectDomains, "redirect-domain", "Allow redirects on successful login to this domain (may be given multiple times)")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -367,6 +367,8 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	redirect_url := req.URL.RequestURI()
 	if req.Header.Get("X-Auth-Request-Redirect") != "" {
 		redirect_url = req.Header.Get("X-Auth-Request-Redirect")
+	} else if req.URL.Query().Get("rd") != "" {
+		redirect_url = req.URL.Query().Get("rd")
 	}
 	if redirect_url == p.SignInPath {
 		redirect_url = "/"

--- a/options.go
+++ b/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 	Footer                   string   `flag:"footer" cfg:"footer"`
+	RedirectDomains          []string `flag:"redirect-domain" cfg:"redirect_domains"`
 
 	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
 	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`


### PR DESCRIPTION
Allows having the oauth2_proxy at e.g. https://auth.example.com and using it for several of your domains, e.g. https://app1.example.com and https://app2.example.com

You will need to whitelist your domains, or set it to "*" to allow all your domains using "--redirect-domain"

Fixes #399 and #427