### PR TITLE
auth: Respect Bearer token authorization.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -655,7 +655,7 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 
 	if session == nil {
-		session, err = p.CheckBasicAuth(req)
+		session, err = p.CheckAuthHeader(req)
 		if err != nil {
 			log.Printf("%s %s", remoteAddr, err)
 		}
@@ -696,19 +696,31 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	return http.StatusAccepted
 }
 
-func (p *OAuthProxy) CheckBasicAuth(req *http.Request) (*providers.SessionState, error) {
-	if p.HtpasswdFile == nil {
-		return nil, nil
-	}
+func (p *OAuthProxy) CheckAuthHeader(req *http.Request) (*providers.SessionState, error) {
 	auth := req.Header.Get("Authorization")
 	if auth == "" {
 		return nil, nil
 	}
 	s := strings.SplitN(auth, " ", 2)
-	if len(s) != 2 || s[0] != "Basic" {
+	if len(s) != 2 {
 		return nil, fmt.Errorf("invalid Authorization header %s", req.Header.Get("Authorization"))
 	}
-	b, err := b64.StdEncoding.DecodeString(s[1])
+
+	switch s[0] {
+	case "Basic":
+		if p.HtpasswdFile == nil {
+			return nil, nil
+		}
+		return p.CheckBasicAuth(s[1])
+	case "Bearer":
+		return p.CheckBearerAuth(s[1])
+	default:
+		return nil, fmt.Errorf("invalid Authorization header, unsupport type %s", s[1])
+	}
+}
+
+func (p *OAuthProxy) CheckBasicAuth(value string) (*providers.SessionState, error) {
+	b, err := b64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return nil, err
 	}
@@ -721,4 +733,16 @@ func (p *OAuthProxy) CheckBasicAuth(req *http.Request) (*providers.SessionState,
 		return &providers.SessionState{User: pair[0]}, nil
 	}
 	return nil, fmt.Errorf("%s not in HtpasswdFile", pair[0])
+}
+
+func (p *OAuthProxy) CheckBearerAuth(value string) (*providers.SessionState, error) {
+	email, err := p.provider.GetEmailAddress(&providers.SessionState{AccessToken: value})
+	if err != nil {
+		return nil, errors.New("invalid bearer token")
+	}
+	return &providers.SessionState{
+		AccessToken: value,
+		Email:       email,
+		User:        email,
+	}, nil
 }


### PR DESCRIPTION
This patch will attempt to verify Authorization: Bearer tokens with
providers. This is useful for proxying of API request.

We have an internal implementation of a provider that uses this to verify JWT tokens. I think that should be upstreamable , and useful to others.