### PR TITLE
Use SHA256 instead of SHA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ If `signature_key` is defined, proxied requests will be signed with the
 of selected request information and the request body [see `SIGNATURE_HEADERS`
 in `oauthproxy.go`](./oauthproxy.go).
 
-`signature_key` must be of the form `algorithm:secretkey`, (ie: `signature_key = "sha1:secret0"`)
+`signature_key` must be of the form `algorithm:secretkey`, (ie: `signature_key = "sha256:secret0"`)
 
 For more information about HMAC request signature validation, read the
 following:

--- a/cookie/cookies.go
+++ b/cookie/cookies.go
@@ -5,7 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -59,7 +59,7 @@ func SignedValue(seed string, key string, value string, now time.Time) string {
 }
 
 func cookieSignature(args ...string) string {
-	h := hmac.New(sha1.New, []byte(args[0]))
+	h := hmac.New(sha256.New, []byte(args[0]))
 	for _, arg := range args[1:] {
 		h.Write([]byte(arg))
 	}

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -806,7 +806,7 @@ func (st *SignatureTest) MakeRequestWithExpectedKey(method, body, key string) {
 	req.AddCookie(cookie)
 	// This is used by the upstream to validate the signature.
 	st.authenticator.auth = hmacauth.NewHmacAuth(
-		crypto.SHA1, []byte(key), SignatureHeader, SignatureHeaders)
+		crypto.SHA256, []byte(key), SignatureHeader, SignatureHeaders)
 	proxy.ServeHTTP(st.rw, req)
 }
 
@@ -821,7 +821,7 @@ func TestNoRequestSignature(t *testing.T) {
 func TestRequestSignatureGetRequest(t *testing.T) {
 	st := NewSignatureTest()
 	defer st.Close()
-	st.opts.SignatureKey = "sha1:foobar"
+	st.opts.SignatureKey = "sha256:foobar"
 	st.MakeRequestWithExpectedKey("GET", "", "foobar")
 	assert.Equal(t, 200, st.rw.Code)
 	assert.Equal(t, st.rw.Body.String(), "signatures match")
@@ -830,7 +830,7 @@ func TestRequestSignatureGetRequest(t *testing.T) {
 func TestRequestSignaturePostRequest(t *testing.T) {
 	st := NewSignatureTest()
 	defer st.Close()
-	st.opts.SignatureKey = "sha1:foobar"
+	st.opts.SignatureKey = "sha256:foobar"
 	payload := `{ "hello": "world!" }`
 	st.MakeRequestWithExpectedKey("POST", payload, "foobar")
 	assert.Equal(t, 200, st.rw.Code)

--- a/options_test.go
+++ b/options_test.go
@@ -195,9 +195,9 @@ func TestBase64CookieSecret(t *testing.T) {
 
 func TestValidateSignatureKey(t *testing.T) {
 	o := testOptions()
-	o.SignatureKey = "sha1:secret"
+	o.SignatureKey = "sha256:secret"
 	assert.Equal(t, nil, o.Validate())
-	assert.Equal(t, o.signatureData.hash, crypto.SHA1)
+	assert.Equal(t, o.signatureData.hash, crypto.SHA256)
 	assert.Equal(t, o.signatureData.key, "secret")
 }
 


### PR DESCRIPTION
SHA1 looks like it can be exploded. SHA256 is an encryption method from SHA2, which is way more secure. This little fix will allow oauth2_proxy to use SHA2 instead and making it even more secure.