### PR TITLE
default to redirecting to current page

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -417,7 +417,7 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 
 	redirect = req.Form.Get("rd")
 	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
-		redirect = "/"
+		redirect = req.URL.RequestURI()
 	}
 
 	return


### PR DESCRIPTION
If "-skip-provider-button" flag is used, currently a user is always
redirected to "/", whereas a user should be redirected to the page, that
was initially requested.

@jehiah 