### PR TITLE
Swap out bmizerany/assert package in favor of stretchr/testify/assert

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,7 +2,7 @@ github.com/18F/hmacauth                  1.0.1
 github.com/BurntSushi/toml               d94612f9fc140360834f9742158c70b5c5b5535b
 github.com/bitly/go-simplejson           da1a8928f709389522c8023062a3739f3b4af419
 github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d
-github.com/bmizerany/assert              e17e99893cb6509f428e1728281c2ad60a6b31e3
+github.com/stretchr/testify              v1.1.4
 gopkg.in/fsnotify.v1                     v1.2.0
 golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"github.com/bitly/go-simplejson"
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testBackend(response_code int, payload string) *httptest.Server {

--- a/cookie/cookies_test.go
+++ b/cookie/cookies_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEncodeAndDecodeAccessToken(t *testing.T) {

--- a/env_options_test.go
+++ b/env_options_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type envTest struct {

--- a/htpasswd_test.go
+++ b/htpasswd_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/18F/hmacauth"
 	"github.com/bitly/oauth2_proxy/providers"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {

--- a/options_test.go
+++ b/options_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func testOptions() *Options {

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -1,11 +1,12 @@
 package providers
 
 import (
-	"github.com/bmizerany/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testAzureProvider(hostname string) *AzureProvider {

--- a/providers/gitlab_test.go
+++ b/providers/gitlab_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func testGitLabProvider(hostname string) *GitLabProvider {

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func newRedeemServer(body []byte) (*url.URL, *httptest.Server) {

--- a/providers/internal_util_test.go
+++ b/providers/internal_util_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type ValidateSessionStateTestProvider struct {

--- a/providers/linkedin_test.go
+++ b/providers/linkedin_test.go
@@ -1,11 +1,12 @@
 package providers
 
 import (
-	"github.com/bmizerany/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func testLinkedInProvider(hostname string) *LinkedInProvider {

--- a/providers/provider_default_test.go
+++ b/providers/provider_default_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRefresh(t *testing.T) {

--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/bitly/oauth2_proxy/cookie"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 const secret = "0123456789abcdefghijklmnopqrstuv"

--- a/templates_test.go
+++ b/templates_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/bmizerany/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTemplatesCompile(t *testing.T) {


### PR DESCRIPTION
This PR closes out https://github.com/bitly/oauth2_proxy/issues/474 by swapping out the deprecated `bmizerany/assert` package in favor of `stretchr/testify/assert`.