### PR TITLE
Upgrade fsnotify to 1.4.2

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -3,7 +3,7 @@ github.com/BurntSushi/toml               d94612f9fc140360834f9742158c70b5c5b5535
 github.com/bitly/go-simplejson           da1a8928f709389522c8023062a3739f3b4af419
 github.com/mreiferson/go-options         77551d20752b54535462404ad9d877ebdb26e53d
 github.com/stretchr/testify              v1.1.4
-gopkg.in/fsnotify.v1                     v1.2.0
+gopkg.in/fsnotify.v1                     v1.4.2
 golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830ca
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
 google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877


### PR DESCRIPTION
There have been a bunch of bug fixes in the last couple of versions: https://github.com/fsnotify/fsnotify/blob/master/CHANGELOG.md