### PR TITLE
providers: update gitlab api endpoint to use latest version, v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you are using self-hosted GitLab, make sure you set the following to the appr
 
     -login-url="<your gitlab url>/oauth/authorize"
     -redeem-url="<your gitlab url>/oauth/token"
-    -validate-url="<your gitlab url>/api/v3/user"
+    -validate-url="<your gitlab url>/api/v4/user"
 
 
 ### LinkedIn Auth Provider

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -32,7 +32,7 @@ func NewGitLabProvider(p *ProviderData) *GitLabProvider {
 		p.ValidateURL = &url.URL{
 			Scheme: "https",
 			Host:   "gitlab.com",
-			Path:   "/api/v3/user",
+			Path:   "/api/v4/user",
 		}
 	}
 	if p.Scope == "" {

--- a/providers/gitlab_test.go
+++ b/providers/gitlab_test.go
@@ -28,7 +28,7 @@ func testGitLabProvider(hostname string) *GitLabProvider {
 }
 
 func testGitLabBackend(payload string) *httptest.Server {
-	path := "/api/v3/user"
+	path := "/api/v4/user"
 	query := "access_token=imaginary_access_token"
 
 	return httptest.NewServer(http.HandlerFunc(
@@ -51,7 +51,7 @@ func TestGitLabProviderDefaults(t *testing.T) {
 		p.Data().LoginURL.String())
 	assert.Equal(t, "https://gitlab.com/oauth/token",
 		p.Data().RedeemURL.String())
-	assert.Equal(t, "https://gitlab.com/api/v3/user",
+	assert.Equal(t, "https://gitlab.com/api/v4/user",
 		p.Data().ValidateURL.String())
 	assert.Equal(t, "read_user", p.Data().Scope)
 }
@@ -70,7 +70,7 @@ func TestGitLabProviderOverrides(t *testing.T) {
 			ValidateURL: &url.URL{
 				Scheme: "https",
 				Host:   "example.com",
-				Path:   "/api/v3/user"},
+				Path:   "/api/v4/user"},
 			Scope: "profile"})
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "GitLab", p.Data().ProviderName)
@@ -78,7 +78,7 @@ func TestGitLabProviderOverrides(t *testing.T) {
 		p.Data().LoginURL.String())
 	assert.Equal(t, "https://example.com/oauth/token",
 		p.Data().RedeemURL.String())
-	assert.Equal(t, "https://example.com/api/v3/user",
+	assert.Equal(t, "https://example.com/api/v4/user",
 		p.Data().ValidateURL.String())
 	assert.Equal(t, "profile", p.Data().Scope)
 }


### PR DESCRIPTION
This PR fixes https://github.com/bitly/oauth2_proxy/issues/441

https://docs.gitlab.com/ce/api/README.html
`API requests should be prefixed with api and the API version. The API version is defined in lib/api.rb. For example, the root of the v4 API is at /api/v4.`