### PR TITLE
options: update options parsing for better handling of incorrect values

### DIFF
--- a/options.go
+++ b/options.go
@@ -180,8 +180,8 @@ func (o *Options) Validate() error {
 	for _, u := range o.SkipAuthRegex {
 		CompiledRegex, err := regexp.Compile(u)
 		if err != nil {
-			msgs = append(msgs, fmt.Sprintf(
-				"error compiling regex=%q %s", u, err))
+			msgs = append(msgs, fmt.Sprintf("error compiling regex=%q %s", u, err))
+			continue
 		}
 		o.CompiledRegex = append(o.CompiledRegex, CompiledRegex)
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -95,6 +95,18 @@ func TestProxyURLs(t *testing.T) {
 	assert.Equal(t, expected, o.proxyURLs)
 }
 
+func TestProxyURLsError(t *testing.T) {
+	o := testOptions()
+	o.Upstreams = append(o.Upstreams, "127.0.0.1:8081")
+	err := o.Validate()
+	assert.NotEqual(t, nil, err)
+
+	expected := errorMsg([]string{
+		"error parsing upstream: parse 127.0.0.1:8081: " +
+			"first path segment in URL cannot contain colon"})
+	assert.Equal(t, expected, err.Error())
+}
+
 func TestCompiledRegex(t *testing.T) {
 	o := testOptions()
 	regexps := []string{"/foo/.*", "/ba[rz]/quux"}
@@ -116,6 +128,15 @@ func TestCompiledRegexError(t *testing.T) {
 	expected := errorMsg([]string{
 		"error compiling regex=\"(foobaz\" error parsing regexp: " +
 			"missing closing ): `(foobaz`",
+		"error compiling regex=\"barquux)\" error parsing regexp: " +
+			"unexpected ): `barquux)`"})
+	assert.Equal(t, expected, err.Error())
+
+	o.SkipAuthRegex = []string{"foobaz", "barquux)"}
+	err = o.Validate()
+	assert.NotEqual(t, nil, err)
+
+	expected = errorMsg([]string{
 		"error compiling regex=\"barquux)\" error parsing regexp: " +
 			"unexpected ): `barquux)`"})
 	assert.Equal(t, expected, err.Error())


### PR DESCRIPTION
This is a follow-up PR to close out https://github.com/bitly/oauth2_proxy/pull/387 . Part of that PR was actually closed out by https://github.com/bitly/oauth2_proxy/pull/431 but we missed adding in some tests for it there so going to do it here.

* don't add in failed compiled regexes for skip auth regex option
* improve test coverage for skip auth regex option to handle partial
success case
* add tests for incorrect upstream options parsing errors