### PR TITLE
distribution: create sha256sum.txt file when creating version releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ to validate accounts by email, domain or group.
 ## Installation
 
 1. Download [Prebuilt Binary](https://github.com/bitly/oauth2_proxy/releases) (current release is `v2.2`) or build with `$ go get github.com/bitly/oauth2_proxy` which will put the binary in `$GOROOT/bin`
+Prebuilt binaries can be validated by extracting the file and verifying it against the `sha256sum.txt` checksum file provided for each release starting with version `v2.3`.
+```
+sha256sum -c sha256sum.txt 2>&1 | grep OK
+oauth2_proxy-2.3.linux-amd64: OK
+```
 2. Select a Provider and Register an OAuth Application with a Provider
 3. Configure OAuth2 Proxy using config file, command line options, or environment variables
 4. Configure SSL or Deploy behind a SSL endpoint (example provided for Nginx)

--- a/dist.sh
+++ b/dist.sh
@@ -5,9 +5,7 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "working dir $DIR"
 mkdir -p $DIR/dist
-mkdir -p $DIR/.godeps
-export GOPATH=$DIR/.godeps:$GOPATH
-GOPATH=$DIR/.godeps gpm install
+dep ensure || exit 1
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)

--- a/dist.sh
+++ b/dist.sh
@@ -13,6 +13,7 @@ os=$(go env GOOS)
 arch=$(go env GOARCH)
 version=$(cat $DIR/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
 goversion=$(go version | awk '{print $3}')
+sha256sum=()
 
 echo "... running tests"
 ./test.sh
@@ -25,10 +26,22 @@ for os in windows linux darwin; do
     fi
     BUILD=$(mktemp -d ${TMPDIR:-/tmp}/oauth2_proxy.XXXXXX)
     TARGET="oauth2_proxy-$version.$os-$arch.$goversion"
+    FILENAME="oauth2_proxy-$version.$os-$arch$EXT"
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
-        go build -ldflags="-s -w" -o $BUILD/$TARGET/oauth2_proxy$EXT || exit 1
-    pushd $BUILD
-    tar czvf $TARGET.tar.gz $TARGET
+        go build -ldflags="-s -w" -o $BUILD/$TARGET/$FILENAME || exit 1
+    pushd $BUILD/$TARGET
+    sha256sum+=("$(shasum -a 256 $FILENAME || exit 1)")
+    cd .. && tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist
     popd
+done
+
+checksum_file="sha256sum.txt"
+cd $DIR/dist
+if [ -f $checksum_file ]; then
+    rm $checksum_file
+fi
+touch $checksum_file
+for checksum in "${sha256sum[@]}"; do
+    echo "$checksum" >> $checksum_file
 done


### PR DESCRIPTION
This PR closes out https://github.com/bitly/oauth2_proxy/issues/479 by:
* creating a sha256sum.txt file containing sha256 checksums for each pre-built binary that we distribute with our releases. we'll have to attach this file to each release manually for now. we may or may not want to commit this file into the repo in the future, but for now this should be a good start.
* updates our README.md file with some instructions on how to verify pre-build binaries using the sha256sum.txt file we provide.