### PR TITLE
Fetch a google group member recursively

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -559,6 +559,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// set cookie, or deny
+	log.Printf("Validate Email %s", session.Email)
 	if p.Validator(session.Email) && p.provider.ValidateGroup(session.Email) {
 		log.Printf("%s authentication complete %s", remoteAddr, session)
 		err := p.SaveSession(rw, req, session)

--- a/providers/google.go
+++ b/providers/google.go
@@ -179,6 +179,7 @@ func getAdminService(adminEmail string, credentialsReader io.Reader) *admin.Serv
 
 func userInGroup(service *admin.Service, groups []string, email string) bool {
 	for _, group := range groups {
+		log.Printf("Is user %s in group %s", email, group)
 		req, err := service.Members.HasMember(group, email).Do()
 		if err != nil {
 			log.Printf("Members API call hasMember error: %s", err)

--- a/providers/google.go
+++ b/providers/google.go
@@ -196,6 +196,7 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 // ValidateGroup validates that the provided email exists in the configured Google
 // group(s).
 func (p *GoogleProvider) ValidateGroup(email string) bool {
+	log.Printf("ValidateGroup %s", email)
 	return p.GroupValidator(email)
 }
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -232,7 +232,12 @@ func fetchGroupMembers(service *admin.Service, group string) ([]*admin.Member, e
 			return nil, err
 		}
 		for _, member := range r.Members {
-			members = append(members, member)
+			if member.Type == "GROUP" {
+				groupMembers, _ := fetchGroupMembers(service, member.Email)
+				members = append(members, groupMembers...)
+			} else {
+				members = append(members, member)
+			}
 		}
 		if r.NextPageToken == "" {
 			break

--- a/providers/google.go
+++ b/providers/google.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/admin/directory/v1"
-	"google.golang.org/api/googleapi"
 )
 
 type GoogleProvider struct {
@@ -179,72 +178,17 @@ func getAdminService(adminEmail string, credentialsReader io.Reader) *admin.Serv
 }
 
 func userInGroup(service *admin.Service, groups []string, email string) bool {
-	user, err := fetchUser(service, email)
-	if err != nil {
-		log.Printf("error fetching user: %v", err)
-		return false
-	}
-	id := user.Id
-	custID := user.CustomerId
-
 	for _, group := range groups {
-		members, err := fetchGroupMembers(service, group)
+		req, err := service.Members.HasMember(group, email).Do()
 		if err != nil {
-			if err, ok := err.(*googleapi.Error); ok && err.Code == 404 {
-				log.Printf("error fetching members for group %s: group does not exist", group)
-			} else {
-				log.Printf("error fetching group members: %v", err)
-				return false
-			}
+			log.Printf("Members API call hasMember error: %s", err)
+			return false
 		}
-
-		for _, member := range members {
-			switch member.Type {
-			case "CUSTOMER":
-				if member.Id == custID {
-					return true
-				}
-			case "USER":
-				if member.Id == id {
-					return true
-				}
-			}
+		if req.IsMember == true {
+			return true
 		}
 	}
 	return false
-}
-
-func fetchUser(service *admin.Service, email string) (*admin.User, error) {
-	user, err := service.Users.Get(email).Do()
-	return user, err
-}
-
-func fetchGroupMembers(service *admin.Service, group string) ([]*admin.Member, error) {
-	members := []*admin.Member{}
-	pageToken := ""
-	for {
-		req := service.Members.List(group)
-		if pageToken != "" {
-			req.PageToken(pageToken)
-		}
-		r, err := req.Do()
-		if err != nil {
-			return nil, err
-		}
-		for _, member := range r.Members {
-			if member.Type == "GROUP" {
-				groupMembers, _ := fetchGroupMembers(service, member.Email)
-				members = append(members, groupMembers...)
-			} else {
-				members = append(members, member)
-			}
-		}
-		if r.NextPageToken == "" {
-			break
-		}
-		pageToken = r.NextPageToken
-	}
-	return members, nil
 }
 
 // ValidateGroup validates that the provided email exists in the configured Google

--- a/providers/google.go
+++ b/providers/google.go
@@ -154,6 +154,7 @@ func (p *GoogleProvider) Redeem(redirectURL, code string) (s *SessionState, err 
 func (p *GoogleProvider) SetGroupRestriction(groups []string, adminEmail string, credentialsReader io.Reader) {
 	adminService := getAdminService(adminEmail, credentialsReader)
 	p.GroupValidator = func(email string) bool {
+		log.Printf("Validate user %s", email)
 		return userInGroup(adminService, groups, email)
 	}
 }


### PR DESCRIPTION
## Problem: 

If you have a group (e.g. `subgroup@test.com`) with a user (e.g `tester@test.com`) and this group is in second group (e.g. `group@test.com`). 
And you set the **-google-group** flag to `group@test.com`.
Than the user `tester@test.com` can't be authorized.

## Solution:

Fetch the google group member recursively.