### PR TITLE
more robust ClearSessionCookie()

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -300,7 +300,15 @@ func (p *OAuthProxy) SetCSRFCookie(rw http.ResponseWriter, req *http.Request, va
 }
 
 func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Request) {
-	http.SetCookie(rw, p.MakeSessionCookie(req, "", time.Hour*-1, time.Now()))
+	clr := p.MakeSessionCookie(req, "", time.Hour*-1, time.Now())
+	http.SetCookie(rw, clr)
+
+	// ugly hack because default domain changed
+	if p.CookieDomain == "" {
+		clr2 := *clr
+		clr2.Domain = req.Host
+		http.SetCookie(rw, &clr2)
+	}
 }
 
 func (p *OAuthProxy) SetSessionCookie(rw http.ResponseWriter, req *http.Request, val string) {


### PR DESCRIPTION
    default domain changed from request Host to blank, recently
    try to clear cookies for both

The combination of #466 and #376 causes this problem where the cookie which could not be parsed also was not cleared, and login never worked:

```
2017-12-12 23:47:54.321 oauthproxy.go:608: 127.0.0.1:49562 ("158.106.212.130") could not decode session state: expected 2 chunks got 1
2017-12-12 23:47:56.665 github.go:178: Found Github Organization:"PhysicalGraph" Team:"platform-video-pizza-box" (Name:"Platform: Video Pizza Box")
2017-12-12 23:47:56.766 github.go:239: got 200 from "https://api.github.com/user/emails" [{"email":"pierce.lopez@gmail.com","primary":true,"verified":true,"visibility":"public"},...]
2017-12-12 23:47:56.882 github.go:288: got 200 from "https://api.github.com/user" {"login":"ploxiln","id":649835,"avatar_url":...}
2017-12-12 23:47:56.882 oauthproxy.go:563: 127.0.0.1:49564 ("158.106.212.130") authentication complete Session{email:pierce.lopez@gmail.com user:ploxiln token:true}
2017-12-12 23:47:56.994 oauthproxy.go:608: 127.0.0.1:49564 ("158.106.212.130") could not decode session state: expected 2 chunks got 1
```

This is an admittedly very cludgy fix which only applies if you use the default cookie domain.

My browser which couldn't re-sign-in was able to re-sign-in after this. The Firefox devtools showed the two cookies with the same name in an awkward and invalid-looking way, but curl confirmed that the cookies were being set as desired:

```
< HTTP/1.1 403 Forbidden
< Server: nginx
< Date: Wed, 13 Dec 2017 01:18:26 GMT
< Content-Type: text/html; charset=utf-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Keep-Alive: timeout=60
< Set-Cookie: _oauth2_proxy=; Path=/; Expires=Wed, 13 Dec 2017 00:18:26 GMT; HttpOnly; Secure
< Set-Cookie: _oauth2_proxy=; Path=/; Domain=avdocs.st-av.net; Expires=Wed, 13 Dec 2017 00:18:26 GMT; HttpOnly; Secure
<
```

cc @reedloden @clobrano @hlhendy 