### PR TITLE
Added example of how to do Azure AD conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Note: The user is checked against the group members list on initial authenticati
 
 The Azure AD auth provider uses `openid` as it default scope. It uses `https://graph.windows.net` as a default protected resource. It call to `https://graph.windows.net/me` to get the email address of the user that logs in.
 
+Configuration should look something like this: 
+
+./oauth2_proxy --provider="azure" --email-domain="example.com" --upstream="" --cookie-secret=... --client-id=...  --client-secret=... --azure-tenant=...
+
+Or in the configuration file you have to add following line:
+provider = azure
+
+
 
 ### Facebook Auth Provider
 


### PR DESCRIPTION
Added and example of how to do Azure AD configuration for oauth2_proxy so it's more clear what happens in oauth2_proxy side. 

Also added note about addition of line provider = azure in the configuration file.