### PR TITLE
README: fix nginx auth_request example for requests with body

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,15 @@ server {
     proxy_set_header X-Scheme                $scheme;
     proxy_set_header X-Auth-Request-Redirect $request_uri;
   }
+  location = /oauth2/auth {
+    proxy_pass       http://127.0.0.1:4180;
+    proxy_set_header Host             $host;
+    proxy_set_header X-Real-IP        $remote_addr;
+    proxy_set_header X-Scheme         $scheme;
+    # nginx auth_request includes headers but not body
+    proxy_set_header Content-Length   "";
+    proxy_pass_request_body           off;
+  }
 
   location / {
     auth_request /oauth2/auth;


### PR DESCRIPTION
Nginx never sends the body with the auth_request sub-request, but
keeps the original Content-Length header by default. Without some
config tweaks, this results in the request to /oauth2/auth hanging.

fixes #442