### PR TITLE
If X-Original-URI header is present, use its value to check against w…

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -603,6 +603,11 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	var saveSession, clearSession, revalidated bool
 	remoteAddr := getRemoteAddr(req)
 
+	originalRequestUri := req.Header.Get("X-Original-URI")
+	if originalRequestUri != "" && p.IsWhitelistedPath(originalRequestUri){
+		return http.StatusAccepted
+	}
+
 	session, sessionAge, err := p.LoadCookiedSession(req)
 	if err != nil {
 		log.Printf("%s %s", remoteAddr, err)

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -596,6 +596,24 @@ func NewAuthOnlyEndpointTest() *ProcessCookieTest {
 	return pc_test
 }
 
+func TestAuthOnlyEndpointAcceptedForWhitelisted(t *testing.T) {
+	test := NewAuthOnlyEndpointTest()
+	test.proxy.skipAuthRegex = []string{"/white"}
+	for _, u := range test.proxy.skipAuthRegex {
+		CompiledRegex, err := regexp.Compile(u)
+		if err != nil {
+			continue
+		}
+		test.proxy.compiledRegex = append(test.proxy.compiledRegex, CompiledRegex)
+	}
+	test.req.Header.Add("X-Original-URI", "/white")
+
+	test.proxy.ServeHTTP(test.rw, test.req)
+	assert.Equal(t, http.StatusAccepted, test.rw.Code)
+	bodyBytes, _ := ioutil.ReadAll(test.rw.Body)
+	assert.Equal(t, "", string(bodyBytes))
+}
+
 func TestAuthOnlyEndpointAccepted(t *testing.T) {
 	test := NewAuthOnlyEndpointTest()
 	startSession := &providers.SessionState{


### PR DESCRIPTION
…hitelist paths. That is useful for nginx auth_request mode.