### PR TITLE
Add option to check hosted domain for google

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
+	flagSet.String("hosted-domain", "", "The hosted domain parameter streamlines the login process for G Suite hosted accounts.")
 	flagSet.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	HttpsAddress string `flag:"https-address" cfg:"https_address"`
+	HostedDomain string `flag:"hosted-domain" cfg:"hosted_domain"` //  env:"OAUTH2_PROXY_HOSTED_DOMAIN"`
 	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
@@ -250,6 +251,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		ClientID:       o.ClientID,
 		ClientSecret:   o.ClientSecret,
 		ApprovalPrompt: o.ApprovalPrompt,
+		HostedDomain:   o.HostedDomain,
 	}
 	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
 	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -15,6 +15,7 @@ type ProviderData struct {
 	ValidateURL       *url.URL
 	Scope             string
 	ApprovalPrompt    string
+	HostedDomain      string
 }
 
 func (p *ProviderData) Data() *ProviderData { return p }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,8 +1,6 @@
 package providers
 
-import (
-	"github.com/bitly/oauth2_proxy/cookie"
-)
+import "github.com/bitly/oauth2_proxy/cookie"
 
 type Provider interface {
 	Data() *ProviderData


### PR DESCRIPTION
This implements #326 

When using the google provider and supplying a `hd` via `--hosted-domain` `oauth2_proxy` will now check for the presence of a hosted domain and return an error if not present.

Let me know if there is anything you'd like me to address code wise.