### PR TITLE
Add simple OAuth2 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,45 @@ OpenID Connect is a spec for OAUTH 2.0 + identity that is implemented by many ma
     -cookie-secure=false
     -email-domain example.com
 
+## Simple OAuth2 Provider
+
+Simple OAuth2 provider requires one endpoint to be implemented on the side of the provider. The steps are:
+
+1. Obtain the auth and token URLs for your application (`login-url` and `redeem-url` below). You will also need to add one endpoint to your application, for
+which the URL can be configured (`profile-url` below). You could for example add an endpoint at `/api/user`. The endpoint should be accessible
+using OAuth2 credentials. It should return JSON data with at least two keys: `username` and `email`. Your application
+should accept the OAuth2 token in the `Authentication` header with token type `Bearer`. So, an example of a request made
+to your application could look like this:
+
+```
+GET /api/user HTTP/1.1
+Host: example.com
+Authorization: Bearer NWJlODM4YzZkZjAxZTUyMmRhMWFjNGEyMTkyM2Y2ODA0ZTMwYmVkOTI5ZTdhM2MxNjQ2MzA4ZWFmNTNmNTE1Ng
+```
+
+Your server would then respond with:
+
+```
+{
+    "username": "John Doe",
+    "email": "john.doe@example.com"
+}
+```
+2. Run oauth2_proxy with the correct settings:
+
+```
+    -provider simple
+    -client-id oauth2_proxy
+    -client-secret proxy
+    -login-url http://localhost:8080/oauth/v2/auth
+    -redeem-url http://localhost:8080/oauth/v2/token
+    -profile-url http://localhost:8080/api/user
+    -redirect-url http://127.0.0.1:4180/oauth2/callback
+    -cookie-secret mysecret
+    -cookie-secure=false
+    -email-domain *
+```
+
 ## Email Authentication
 
 To authorize by email domain use `--email-domain=yourcompany.com`. To authorize individual email addresses use `--authenticated-emails-file=/path/to/file` with one email per line. To authorize all email addresses use `--email-domain=*`.

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -31,6 +31,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewGitLabProvider(p)
 	case "oidc":
 		return NewOIDCProvider(p)
+	case "simple":
+		return NewSimpleProvider(p)
 	default:
 		return NewGoogleProvider(p)
 	}

--- a/providers/simple.go
+++ b/providers/simple.go
@@ -1,0 +1,69 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type SimpleProvider struct {
+	*ProviderData
+}
+
+func NewSimpleProvider(p *ProviderData) *SimpleProvider {
+	p.ProviderName = "Simple"
+	return &SimpleProvider{ProviderData: p}
+}
+
+func (p *SimpleProvider) GetEmailAddress(s *SessionState) (string, error) {
+	_, email, err := p.getUserAndEmail(s)
+	return email, err
+}
+
+func (p *SimpleProvider) GetUserName(s *SessionState) (string, error) {
+	username, _, err := p.getUserAndEmail(s)
+	if err != nil {
+		return "", err
+	}
+	// Replace all spaces in the username by an alternative character because space is used to delimit session state.
+	return strings.Replace(username, " ", "+", -1), err
+}
+
+func (p *SimpleProvider) getUserAndEmail(s *SessionState) (string, string, error) {
+	var user struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+	}
+
+	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	if err != nil {
+		return "", "", fmt.Errorf("could not create new GET request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.AccessToken))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return "", "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", "", fmt.Errorf("got %d from %q %s", resp.StatusCode, p.ProfileURL.String(), body)
+	}
+
+	log.Printf("got %d from %q %s", resp.StatusCode, p.ProfileURL.String(), body)
+
+	if err := json.Unmarshal(body, &user); err != nil {
+		return "", "", fmt.Errorf("%s unmarshaling %s", err, body)
+	}
+
+	return user.Username, user.Email, nil
+}


### PR DESCRIPTION
This will allow anyone to implement their own provider very easily by just implementing one endpoint which provides a user's name and e-mail address.