### PR TITLE
Added allowed-url option for secure allowance of custom redirection URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
+	flagSet.String("allowed-url", "", "Regexp for allowed redirect URLs")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 

--- a/options.go
+++ b/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form"`
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir"`
 	Footer                   string   `flag:"footer" cfg:"footer"`
+	AllowedURL               string   `flag:"allowed-url" cfg:"allowed-url"`
 
 	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
 	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`


### PR DESCRIPTION
That is a small change which adding one option - "**allowed-url**" which able user to set regex for validate "rd" option instead of just replacing it to '/' if it contain absolute path.

### Why?
Because if you have many services on different domains (as example - kubernetes cluster with tens of services) and want to protect them, you don't want to deploy many oauth2_proxy one per domain, you want to use one oauth2_proxy and validate redirection URLs for make redirection secure.

### Example of usage
Adding option `--allowed-url=.+\.internals\.example\.com` will allow you to use one proxy for all services in subdomain .internals.example.com.

### Is it tested?
I built a container with that change - onlinehead/oauth2_proxy:2.2.1 and tested it on my K8s cluster in pair of GitLab as Oauth provider. And looks like it working OK.

P.S. I am not sure that name of the option is right.