### PR TITLE
rd param allows other domain

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -426,7 +426,8 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 	}
 
 	redirect = req.Form.Get("rd")
-	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	u, err := url.ParseRequestURI(redirect)
+	if err != nil || (u.Host != "" && (u.Scheme != "http" && u.Scheme != "https")) {
 		redirect = "/"
 	}
 
@@ -562,7 +563,8 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	u, err := url.ParseRequestURI(redirect)
+	if err != nil || (u.Host != "" && (u.Scheme != "http" && u.Scheme != "https")) {
 		redirect = "/"
 	}
 


### PR DESCRIPTION
`rd` param at `/oauth2/start` currently allows only the path starts with `/`.
Otherwise the request is redirected to `/` even if rd param is required to allow other domain URI.
This commit will work on following nginx snippet:
```
location /secret {
    satisfy any;
    auth_request /oauth2/auth;
    error_page 401 = /oauth2/start?rd=$scheme://$host$uri;
}
```
which is useful for multiple path required to authenticated.