### PR TITLE
Add a Makefile and a Dockerfile which automates the build and release steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.9.4-alpine3.7
+
+ENV BIN=oauth2_proxy
+
+COPY build/*-linux-amd64 /go/bin/$BIN
+
+CMD /go/bin/$BIN

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+VERSION ?= $(shell git describe --always --tags)
+BIN = oauth2_proxy
+BUILD_CMD = go build -o build/$(BIN)-$(VERSION)-$${GOOS}-$${GOARCH} &
+IMAGE_REPO = docker.io
+
+default:
+	$(MAKE) bootstrap
+	$(MAKE) build
+
+test:
+	go vet ./...
+	golint -set_exit_status $(shell go list ./... | grep -v vendor)
+	go test -covermode=atomic -race -v ./...
+bootstrap:
+	dep ensure
+build:
+	go build -o $(BIN)
+clean:
+	rm -rf build vendor
+	rm -f release image bootstrap $(BIN)
+release: bootstrap
+	@echo "Running build command..."
+	bash -c '\
+		export GOOS=linux; export GOARCH=amd64; export CGO_ENABLED=0; $(BUILD_CMD) \
+		wait \
+	'
+	touch release
+
+image: release
+	@echo "Building the Docker image..."
+	docker build -t $(IMAGE_REPO)/$(BIN):$(VERSION) .
+	docker tag $(IMAGE_REPO)/$(BIN):$(VERSION) $(IMAGE_REPO)/$(BIN):latest
+	touch image
+
+image-push: image
+	docker push $(IMAGE_REPO)/$(BIN):$(VERSION)
+	docker push $(IMAGE_REPO)/$(BIN):latest
+
+.PHONY: test build clean image-push
+


### PR DESCRIPTION
The following build commands are supported:

Build:
`make`

Run tests:
`make test`

Make a release:
`make release`

Make a release and build the docker image:
`make image`

Publish the docker image:
`make image-push`