### PR TITLE
Add support for AWS request signing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "767c40d6a2e058483c25fa193e963a22da17236d"
-  version = "v0.18.0"
+  revision = "2d3a6656c17a60b0815b7e06ab0be04eacb6e613"
+  version = "v0.16.0"
 
 [[projects]]
   name = "github.com/BurntSushi/toml"
@@ -51,20 +51,10 @@
   version = "v0.5.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/bitly/oauth2_proxy"
-  packages = [
-    "api",
-    "cookie",
-    "providers"
-  ]
-  revision = "ae49c7d23c8bc677ff44b4a6273c07d94049ef65"
-
-[[projects]]
   branch = "v2"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
-  revision = "065b426bd41667456c1a924468f507673629c46b"
+  revision = "77e7f2010a464ade7338597afe650dfcffbe2ca8"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -73,21 +63,10 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
-
-[[projects]]
+  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
-
-[[projects]]
-  name = "github.com/jmespath/go-jmespath"
-  packages = ["."]
-  revision = "0b12d6b5"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   name = "github.com/mbland/hmacauth"
@@ -110,10 +89,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/pquerna/cachecontrol"
-  packages = [
-    ".",
-    "cacheobject"
-  ]
+  packages = [".","cacheobject"]
   revision = "0dec1b30a0215bb68605dfc568e8855066c9202d"
 
 [[projects]]
@@ -125,58 +101,30 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "ed25519",
-    "ed25519/internal/edwards25519"
-  ]
-  revision = "432090b8f568c018896cd8a0fb0345872bbac6ce"
+  packages = ["ed25519","ed25519/internal/edwards25519"]
+  revision = "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "context/ctxhttp"
-  ]
-  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
+  packages = ["context","context/ctxhttp"]
+  revision = "9dfe39835686865bff950a07b394c12a98ddc811"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "google",
-    "internal",
-    "jws",
-    "jwt"
-  ]
-  revision = "543e37812f10c46c622c9575afd7ad22f22a12ba"
+  packages = [".","google","internal","jws","jwt"]
+  revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = [
-    "admin/directory/v1",
-    "gensupport",
-    "googleapi",
-    "googleapi/internal/uritemplates"
-  ]
-  revision = "c76a25da6c114df45a86acb8873ae83eda1430b9"
+  packages = ["admin/directory/v1","gensupport","googleapi","googleapi/internal/uritemplates"]
+  revision = "8791354e7ab150705ede13637a18c1fcc16b62e8"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [
-    ".",
-    "internal",
-    "internal/app_identity",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/modules",
-    "internal/remote_api",
-    "internal/urlfetch",
-    "urlfetch"
-  ]
+  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -188,17 +136,13 @@
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = [
-    ".",
-    "cipher",
-    "json"
-  ]
+  packages = [".","cipher","json"]
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c2f9ee6a3d5f57025f297562c306053d5ea214f373930e1c802ffd43f8f103b7"
+  inputs-digest = "efab48a0e196c2a849bfbe9aa02d2ae28d281ce1bfe9f23720d648858eefc8e6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "2d3a6656c17a60b0815b7e06ab0be04eacb6e613"
-  version = "v0.16.0"
+  revision = "767c40d6a2e058483c25fa193e963a22da17236d"
+  version = "v0.18.0"
 
 [[projects]]
   name = "github.com/BurntSushi/toml"
@@ -14,16 +14,57 @@
   version = "v0.3.0"
 
 [[projects]]
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/sts"
+  ]
+  revision = "63324a33d7e42a386c04d4daec764a3de243492e"
+  version = "v1.13.0"
+
+[[projects]]
   name = "github.com/bitly/go-simplejson"
   packages = ["."]
   revision = "aabad6e819789e569bd6aabf444c935aa9ba1e44"
   version = "v0.5.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/bitly/oauth2_proxy"
+  packages = [
+    "api",
+    "cookie",
+    "providers"
+  ]
+  revision = "ae49c7d23c8bc677ff44b4a6273c07d94049ef65"
+
+[[projects]]
   branch = "v2"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
-  revision = "77e7f2010a464ade7338597afe650dfcffbe2ca8"
+  revision = "065b426bd41667456c1a924468f507673629c46b"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -32,10 +73,21 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
+  version = "v1.32.0"
+
+[[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/mbland/hmacauth"
@@ -58,7 +110,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/pquerna/cachecontrol"
-  packages = [".","cacheobject"]
+  packages = [
+    ".",
+    "cacheobject"
+  ]
   revision = "0dec1b30a0215bb68605dfc568e8855066c9202d"
 
 [[projects]]
@@ -70,30 +125,58 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ed25519","ed25519/internal/edwards25519"]
-  revision = "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94"
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519"
+  ]
+  revision = "432090b8f568c018896cd8a0fb0345872bbac6ce"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
-  revision = "9dfe39835686865bff950a07b394c12a98ddc811"
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
+  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","google","internal","jws","jwt"]
-  revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt"
+  ]
+  revision = "543e37812f10c46c622c9575afd7ad22f22a12ba"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = ["admin/directory/v1","gensupport","googleapi","googleapi/internal/uritemplates"]
-  revision = "8791354e7ab150705ede13637a18c1fcc16b62e8"
+  packages = [
+    "admin/directory/v1",
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates"
+  ]
+  revision = "c76a25da6c114df45a86acb8873ae83eda1430b9"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -105,13 +188,17 @@
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = [".","cipher","json"]
+  packages = [
+    ".",
+    "cipher",
+    "json"
+  ]
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "efab48a0e196c2a849bfbe9aa02d2ae28d281ce1bfe9f23720d648858eefc8e6"
+  inputs-digest = "c2f9ee6a3d5f57025f297562c306053d5ea214f373930e1c802ffd43f8f103b7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,10 +33,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/bitly/oauth2_proxy"
-
-[[constraint]]
-  branch = "master"
   name = "google.golang.org/api"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,6 +33,10 @@
 
 [[constraint]]
   branch = "master"
+  name = "github.com/bitly/oauth2_proxy"
+
+[[constraint]]
+  branch = "master"
   name = "google.golang.org/api"
 
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -343,8 +343,6 @@ in `oauthproxy.go`](./oauthproxy.go).
 For more information about HMAC request signature validation, read the
 following:
 
-* [Amazon Web Services: Signing and Authenticating REST
-  Requests](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
 * [rc3.org: Using HMAC to authenticate Web service
   requests](http://rc3.org/2011/12/02/using-hmac-to-authenticate-web-service-requests/)
 
@@ -353,6 +351,11 @@ following:
 If `sign-aws-request-region` is defined, proxied requests will be signed with an `Authorization` header,
 which is used by AWS to authenticate requests to protected services (e.g. Kibana).  You must provide both
 the `sign-aws-request-region` and `sign-aws-request-service` flags for this feature to work.
+
+For more information about signing AWS requests, read the following:
+
+* [Amazon Web Services: Signing and Authenticating REST
+  Requests](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
 
 ## Logging Format
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Usage of oauth2_proxy:
   -resource string: The resource that is protected (Azure AD only)
   -scope string: OAuth scope specification
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
+  -sign-aws-request-region: sign requests with Authorization header for AWS authentication in this region (e.g. "us-east-1").  You must also provide the -sign-aws-request-service flag.
+  -sign-aws-request-service: sign requests with Authorization header for AWS authentication for this service (e.g. "es").  You must also provide the -sign-aws-request-region flag.
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
@@ -345,6 +347,12 @@ following:
   Requests](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
 * [rc3.org: Using HMAC to authenticate Web service
   requests](http://rc3.org/2011/12/02/using-hmac-to-authenticate-web-service-requests/)
+
+## Signing AWS Requests
+
+If `sign-aws-request-region` is defined, proxied requests will be signed with an `Authorization` header,
+which is used by AWS to authenticate requests to protected services (e.g. Kibana).  You must provide both
+the `sign-aws-request-region` and `sign-aws-request-service` flags for this feature to work.
 
 ## Logging Format
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,9 @@ func main() {
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
+	flagSet.String("sign-aws-request-region", "", "Sign upstream requests with AWS credentials for this region")
+	flagSet.String("sign-aws-request-service", "", "Sign upstream requests with AWS credentials for this service")
+
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")

--- a/options.go
+++ b/options.go
@@ -61,6 +61,8 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	SignAWSRequestRegion  string   `flag:"sign-aws-request-region" cfg:"sign_aws_request_region"`
+	SignAWSRequestService string   `flag:"sign-aws-request-service" cfg:"sign_aws_request_service"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.


### PR DESCRIPTION
This adds support for signing upstream requests with an AWS-style `Authorization` header.  This is used for AWS services like AWS Elasticsearch and AWS Kibana, which can be configured to require the client to present a valid authorization token.

To use this feature, you need to have your `~/.aws` directory configured (using the AWS CLI client) or set the `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` environmental variables.  You will also need to pass two flags, `sign-aws-request-region` and `sign-aws-request-service`, which specify the AWS service and region you are attempting to access on the upstream request.