### PR TITLE
Strip JWT base64 padding before parsing. #560

### DIFF
--- a/providers/google.go
+++ b/providers/google.go
@@ -67,7 +67,8 @@ func emailFromIdToken(idToken string) (string, error) {
 	// id_token is a base64 encode ID token payload
 	// https://developers.google.com/accounts/docs/OAuth2Login#obtainuserinfo
 	jwt := strings.Split(idToken, ".")
-	b, err := base64.RawURLEncoding.DecodeString(jwt[1])
+	jwtData := strings.TrimSuffix(jwt[1], "=")
+	b, err := base64.RawURLEncoding.DecodeString(jwtData)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This provider used to allow padding, until it was switched to the builtin RawURLEncoding. This PR fixes the regression by accepting padding again via throwing the padding away.

Google doesn't include padding, but other OAuth2 servers may, and this provider is the default when using a custom provider.