### PR TITLE
feat(oauth): add new route to retrieve user info

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Usage of oauth2_proxy:
   -profile-url string: Profile access endpoint
   -provider string: OAuth provider (default "google")
   -proxy-prefix string: the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in) (default "/oauth2")
+  -allow-token-request allow authenticated GET requests to {proxy-prefix}/token to output access_token, refresh_token, username, email and expires (default: false)
   -redeem-url string: Token redemption endpoint
   -redirect-url string: the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
   -request-logging: Log requests to stdout (default true)

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
 	flagSet.String("footer", "", "custom footer string. Use \"-\" to disable default footer.")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
+	flagSet.Bool("allow-token-request", false, "Allow authenticated GET requests to {proxy-prefix}/token to output access_token, refresh_token, username, email and expires.")
 
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies (optionally base64 encoded)")

--- a/options.go
+++ b/options.go
@@ -61,6 +61,7 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	AllowTokenRequest     bool     `flag:"allow-token-request" cfg:"allow_token_request"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -106,6 +107,7 @@ func NewOptions() *Options {
 		CookieRefresh:        time.Duration(0),
 		SetXAuthRequest:      false,
 		SkipAuthPreflight:    false,
+		AllowTokenRequest:    false,
 		PassBasicAuth:        true,
 		PassUserHeaders:      true,
 		PassAccessToken:      false,

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -10,11 +10,11 @@ import (
 )
 
 type SessionState struct {
-	AccessToken  string
-	ExpiresOn    time.Time
-	RefreshToken string
-	Email        string
-	User         string
+	AccessToken  string    `json:"access_token"`
+	ExpiresOn    time.Time `json:"expires_on"`
+	RefreshToken string    `json:"refresh_token"`
+	Email        string    `json:"email"`
+	User         string    `json:"user"`
 }
 
 func (s *SessionState) IsExpired() bool {


### PR DESCRIPTION
GET {proxy-prefix}/token will output access_token,
refresh_token, username, email and expires in json
format, if the route is enabled (default: off).

Ref #571