### PR TITLE
Fix `dep` warning on unused hmacauth import.

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 #
 
 [[constraint]]
-  name = "github.com/18F/hmacauth"
+  name = "github.com/mbland/hmacauth"
   version = "~1.0.1"
 
 [[constraint]]


### PR DESCRIPTION
The `Gopkg.toml` file requires `github.com/18F/hmacauth`, but the lockfile and source code import `github.com/mbland/hmacauth`. This leads to a warning on `dep ensure`:

```
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/18F/hmacauth

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.
```

This patch fixes `Gopkg.toml` to require the `hmacauth` library at its new home with @mbland.