### PR TITLE
Fixed nginx 401 redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ server {
 
   location / {
     auth_request /oauth2/auth;
-    error_page 401 = /oauth2/sign_in;
+    error_page 401 /oauth2/sign_in;
 
     # pass information via X-User and X-Email headers to backend,
     # requires running with --set-xauthrequest flag


### PR DESCRIPTION
The 401 redirect in the nginx example is broken in the latest version of nginx.
Ref: https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-to-use-custom-error-pages-on-ubuntu-14-04#configuring-nginx-to-use-your-error-pages