### PR TITLE
update fsnotify package name, as recommended by fsnotify doc

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6"
+  version = "v1.2.11"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
@@ -131,12 +137,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "gopkg.in/fsnotify.v1"
-  packages = ["."]
-  revision = "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6"
-  version = "v1.2.11"
-
-[[projects]]
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -149,6 +149,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b502c41a61115d14d6379be26b0300f65d173bdad852f0170d387ebf2d7ec173"
+  inputs-digest = "920ee607248267a40e44510630122195ec608388e30e73263968c0d76a20a00c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
   name = "google.golang.org/api"
 
 [[constraint]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "github.com/fsnotify/fsnotify"
   version = "~1.2.0"
 
 [[constraint]]

--- a/watcher.go
+++ b/watcher.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"gopkg.in/fsnotify.v1"
+	"github.com/fsnotify/fsnotify"
 )
 
 func WaitForReplacement(filename string, op fsnotify.Op,


### PR DESCRIPTION
Fix for #573 to make `dep ensure` work 

Similar to #574, but uses package name (`github.com/fsnotify/fsnotify`) as recommended [here](https://godoc.org/github.com/fsnotify/fsnotify)
Their example in https://github.com/fsnotify/fsnotify/blob/master/example_test.go also use `github.com/fsnotify/fsnotify` as package name