### PR TITLE
Accept self-signed certificates in backend.

### DIFF
--- a/options.go
+++ b/options.go
@@ -131,6 +131,7 @@ func (o *Options) Validate() error {
 		insecureTransport := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		http.DefaultClient = &http.Client{Transport: insecureTransport}
 	}
 


### PR DESCRIPTION
Current implementation doesn't accept self-signed certificates. This change make InsecureSkipVerify work better. 