### PR TITLE
Add secure middleware to enable more header options

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/mreiferson/go-options"
+	"github.com/unrolled/secure"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/mreiferson/go-options"
-	"github.com/unrolled/secure"
 )
 
 func main() {
@@ -147,29 +146,8 @@ func main() {
 		}
 	}
 
-	secureMiddleware := secure.New(secure.Options{
-		AllowedHosts: opts.HttpAllowedHosts,
-		HostsProxyHeaders: opts.HttpHostsProxyHeaders,
-		SSLRedirect: opts.HttpSSLRedirect,
-		SSLTemporaryRedirect: opts.HttpSSLTemporaryRedirect,
-		SSLHost: opts.HttpSSLHost,
-		STSSeconds: opts.HttpSTSSeconds,
-		STSIncludeSubdomains: opts.HttpSTSIncludeSubdomains,
-		STSPreload: opts.HttpSTSPreload,
-		ForceSTSHeader: opts.HttpForceSTSHeader,
-		FrameDeny: opts.HttpFrameDeny,
-		CustomFrameOptionsValue: opts.HttpCustomFrameOptionsValue,
-		ContentTypeNosniff: opts.HttpContentTypeNosniff,
-		BrowserXssFilter: opts.HttpBrowserXssFilter,
-		CustomBrowserXssValue: opts.HttpCustomBrowserXssValue,
-		ContentSecurityPolicy: opts.HttpContentSecurityPolicy,
-		PublicKey: opts.HttpPublicKey,
-		ReferrerPolicy: opts.HttpReferrerPolicy,
-	})
-	h := LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat)
-
 	s := &Server{
-		Handler: secureMiddleware.Handler(h),
+		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat),
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/main.go
+++ b/main.go
@@ -127,7 +127,28 @@ func main() {
 		os.Exit(1)
 	}
 	validator := NewValidator(opts.EmailDomains, opts.AuthenticatedEmailsFile)
-	oauthproxy := NewOAuthProxy(opts, validator)
+	bareproxy := NewOAuthProxy(opts, validator)
+	secureMiddleware := secure.New(secure.Options{
+		AllowedHosts: opts.HttpAllowedHosts,
+		HostsProxyHeaders: opts.HttpHostsProxyHeaders,
+		SSLRedirect: opts.HttpSSLRedirect,
+		SSLTemporaryRedirect: opts.HttpSSLTemporaryRedirect,
+		SSLHost: opts.HttpSSLHost,
+		STSSeconds: opts.HttpSTSSeconds,
+		STSIncludeSubdomains: opts.HttpSTSIncludeSubdomains,
+		STSPreload: opts.HttpSTSPreload,
+		ForceSTSHeader: opts.HttpForceSTSHeader,
+		FrameDeny: opts.HttpFrameDeny,
+		CustomFrameOptionsValue: opts.HttpCustomFrameOptionsValue,
+		ContentTypeNosniff: opts.HttpContentTypeNosniff,
+		BrowserXssFilter: opts.HttpBrowserXssFilter,
+		CustomBrowserXssValue: opts.HttpCustomBrowserXssValue,
+		ContentSecurityPolicy: opts.HttpContentSecurityPolicy,
+		PublicKey: opts.HttpPublicKey,
+		ReferrerPolicy: opts.HttpReferrerPolicy,
+	})
+	oauthproxy := secureMiddleware.Handler(bareproxy)
+
 
 	if len(opts.EmailDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
 		if len(opts.EmailDomains) > 1 {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bitly/oauth2_proxy/cookie"
 	"github.com/bitly/oauth2_proxy/providers"
 	"github.com/mbland/hmacauth"
-	"github.com/unrolled/secure"
 )
 
 const SignatureHeader = "GAP-Signature"
@@ -118,25 +117,6 @@ func NewFileServer(path string, filesystemPath string) (proxy http.Handler) {
 
 func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
-	secureMiddleware := secure.New(secure.Options{
-		AllowedHosts: opts.HttpAllowedHosts,
-		HostsProxyHeaders: opts.HttpHostsProxyHeaders,
-		SSLRedirect: opts.HttpSSLRedirect,
-		SSLTemporaryRedirect: opts.HttpSSLTemporaryRedirect,
-		SSLHost: opts.HttpSSLHost,
-		STSSeconds: opts.HttpSTSSeconds,
-		STSIncludeSubdomains: opts.HttpSTSIncludeSubdomains,
-		STSPreload: opts.HttpSTSPreload,
-		ForceSTSHeader: opts.HttpForceSTSHeader,
-		FrameDeny: opts.HttpFrameDeny,
-		CustomFrameOptionsValue: opts.HttpCustomFrameOptionsValue,
-		ContentTypeNosniff: opts.HttpContentTypeNosniff,
-		BrowserXssFilter: opts.HttpBrowserXssFilter,
-		CustomBrowserXssValue: opts.HttpCustomBrowserXssValue,
-		ContentSecurityPolicy: opts.HttpContentSecurityPolicy,
-		PublicKey: opts.HttpPublicKey,
-		ReferrerPolicy: opts.HttpReferrerPolicy,
-	})
 	var auth hmacauth.HmacAuth
 	if sigData := opts.signatureData; sigData != nil {
 		auth = hmacauth.NewHmacAuth(sigData.hash, []byte(sigData.key),
@@ -155,15 +135,14 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 				setProxyDirector(proxy)
 			}
 			serveMux.Handle(path,
-				secureMiddleware.Handler(&UpstreamProxy{u.Host, proxy, auth}))
+				&UpstreamProxy{u.Host, proxy, auth})
 		case "file":
 			if u.Fragment != "" {
 				path = u.Fragment
 			}
 			log.Printf("mapping path %q => file system %q", path, u.Path)
 			proxy := NewFileServer(path, u.Path)
-			serveMux.Handle(path,
-				secureMiddleware.Handler(&UpstreamProxy{path, proxy, nil}))
+			serveMux.Handle(path, &UpstreamProxy{path, proxy, nil})
 		default:
 			panic(fmt.Sprintf("unknown upstream protocol %s", u.Scheme))
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -118,7 +118,6 @@ func NewFileServer(path string, filesystemPath string) (proxy http.Handler) {
 
 func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
-
 	var auth hmacauth.HmacAuth
 	if sigData := opts.signatureData; sigData != nil {
 		auth = hmacauth.NewHmacAuth(sigData.hash, []byte(sigData.key),
@@ -192,7 +191,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		PublicKey: opts.HttpPublicKey,
 		ReferrerPolicy: opts.HttpReferrerPolicy,
 	})
-	
+
 	return &OAuthProxy{
 		CookieName:     opts.CookieName,
 		CSRFCookieName: fmt.Sprintf("%v_%v", opts.CookieName, "csrf"),

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -863,5 +863,6 @@ func TestHttpBrowserXssFilterFalseBydefault(t *testing.T) {
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
 	proxy.ServeHTTP(rw, req)
+	assert.Equal(t, false, opts.HttpBrowserXssFilter)
 	assert.Equal(t, "", rw.HeaderMap.Get("X-XSS-Protection"))
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bitly/oauth2_proxy/providers"
 	"github.com/mbland/hmacauth"
 	"github.com/stretchr/testify/assert"
+	"github.com/unrolled/secure"
 )
 
 func init() {
@@ -845,7 +846,27 @@ func TestHttpBrowserXssFilterTrue(t *testing.T) {
 	opts.HttpBrowserXssFilter = true
 	opts.Validate()
 
-	proxy := NewOAuthProxy(opts, func(string) bool { return true })
+	bareproxy := NewOAuthProxy(opts, func(string) bool { return true })
+	secureMiddleware := secure.New(secure.Options{
+		AllowedHosts: opts.HttpAllowedHosts,
+		HostsProxyHeaders: opts.HttpHostsProxyHeaders,
+		SSLRedirect: opts.HttpSSLRedirect,
+		SSLTemporaryRedirect: opts.HttpSSLTemporaryRedirect,
+		SSLHost: opts.HttpSSLHost,
+		STSSeconds: opts.HttpSTSSeconds,
+		STSIncludeSubdomains: opts.HttpSTSIncludeSubdomains,
+		STSPreload: opts.HttpSTSPreload,
+		ForceSTSHeader: opts.HttpForceSTSHeader,
+		FrameDeny: opts.HttpFrameDeny,
+		CustomFrameOptionsValue: opts.HttpCustomFrameOptionsValue,
+		ContentTypeNosniff: opts.HttpContentTypeNosniff,
+		BrowserXssFilter: opts.HttpBrowserXssFilter,
+		CustomBrowserXssValue: opts.HttpCustomBrowserXssValue,
+		ContentSecurityPolicy: opts.HttpContentSecurityPolicy,
+		PublicKey: opts.HttpPublicKey,
+		ReferrerPolicy: opts.HttpReferrerPolicy,
+	})
+	proxy := secureMiddleware.Handler(bareproxy)
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
 	proxy.ServeHTTP(rw, req)
@@ -859,7 +880,27 @@ func TestHttpBrowserXssFilterFalseBydefault(t *testing.T) {
 	opts.CookieSecret = "xyzzyplugh"
 	opts.Validate()
 
-	proxy := NewOAuthProxy(opts, func(string) bool { return true })
+	bareproxy := NewOAuthProxy(opts, func(string) bool { return true })
+	secureMiddleware := secure.New(secure.Options{
+		AllowedHosts: opts.HttpAllowedHosts,
+		HostsProxyHeaders: opts.HttpHostsProxyHeaders,
+		SSLRedirect: opts.HttpSSLRedirect,
+		SSLTemporaryRedirect: opts.HttpSSLTemporaryRedirect,
+		SSLHost: opts.HttpSSLHost,
+		STSSeconds: opts.HttpSTSSeconds,
+		STSIncludeSubdomains: opts.HttpSTSIncludeSubdomains,
+		STSPreload: opts.HttpSTSPreload,
+		ForceSTSHeader: opts.HttpForceSTSHeader,
+		FrameDeny: opts.HttpFrameDeny,
+		CustomFrameOptionsValue: opts.HttpCustomFrameOptionsValue,
+		ContentTypeNosniff: opts.HttpContentTypeNosniff,
+		BrowserXssFilter: opts.HttpBrowserXssFilter,
+		CustomBrowserXssValue: opts.HttpCustomBrowserXssValue,
+		ContentSecurityPolicy: opts.HttpContentSecurityPolicy,
+		PublicKey: opts.HttpPublicKey,
+		ReferrerPolicy: opts.HttpReferrerPolicy,
+	})
+	proxy := secureMiddleware.Handler(bareproxy)
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
 	proxy.ServeHTTP(rw, req)

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -852,7 +852,7 @@ func TestHttpBrowserXssFilterTrue(t *testing.T) {
 	assert.Equal(t, "1; mode=block", rw.HeaderMap.Get("X-XSS-Protection"))
 }
 
-func TestHttpBrowserXssFilterFalse(t *testing.T) {
+func TestHttpBrowserXssFilterFalseBydefault(t *testing.T) {
 	opts := NewOptions()
 	opts.ClientID = "bazquux"
 	opts.ClientSecret = "foobar"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -836,3 +836,32 @@ func TestRequestSignaturePostRequest(t *testing.T) {
 	assert.Equal(t, 200, st.rw.Code)
 	assert.Equal(t, st.rw.Body.String(), "signatures match")
 }
+
+func TestHttpBrowserXssFilterTrue(t *testing.T) {
+	opts := NewOptions()
+	opts.ClientID = "bazquux"
+	opts.ClientSecret = "foobar"
+	opts.CookieSecret = "xyzzyplugh"
+	opts.HttpBrowserXssFilter = true
+	opts.Validate()
+
+	proxy := NewOAuthProxy(opts, func(string) bool { return true })
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	proxy.ServeHTTP(rw, req)
+	assert.Equal(t, "1; mode=block", rw.HeaderMap.Get("X-XSS-Protection"))
+}
+
+func TestHttpBrowserXssFilterFalse(t *testing.T) {
+	opts := NewOptions()
+	opts.ClientID = "bazquux"
+	opts.ClientSecret = "foobar"
+	opts.CookieSecret = "xyzzyplugh"
+	opts.Validate()
+
+	proxy := NewOAuthProxy(opts, func(string) bool { return true })
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	proxy.ServeHTTP(rw, req)
+	assert.Equal(t, "", rw.HeaderMap.Get("X-XSS-Protection"))
+}

--- a/options.go
+++ b/options.go
@@ -79,6 +79,25 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
+	// These are options that allow you to tune various parameters for https://github.com/unrolled/secure
+	HttpAllowedHosts			[]string	`flag:"httpAllowedHosts" cfg:"httpAllowedHosts"`
+	HttpHostsProxyHeaders		[]string	`flag:"httpHostsProxyHeaders" cfg:"httpHostsProxyHeaders"`
+	HttpSSLRedirect				bool		`flag:"httpSSLRedirect" cfg:"httpSSLRedirect"`
+	HttpSSLTemporaryRedirect	bool		`flag:"httpSSLTemporaryRedirect" cfg:"httpSSLTemporaryRedirect"`
+	HttpSSLHost					string 		`flag:"httpSSLHost" cfg:"httpSSLHost"`
+	HttpSTSSeconds				int64 		`flag:"httpSTSSeconds" cfg:"httpSTSSeconds"`
+	HttpSTSIncludeSubdomains	bool 		`flag:"httpSTSIncludeSubdomains" cfg:"httpSTSIncludeSubdomains"`
+	HttpSTSPreload				bool		`flag:"httpSTSPreload" cfg:"httpSTSPreload"`
+	HttpForceSTSHeader			bool		`flag:"httpForceSTSHeader" cfg:"httpForceSTSHeader"`
+	HttpFrameDeny				bool		`flag:"httpFrameDeny" cfg:"httpFrameDeny"`
+	HttpCustomFrameOptionsValue	string 		`flag:"httpCustomFrameOptionsValue" cfg:"httpCustomFrameOptionsValue"`
+	HttpContentTypeNosniff		bool		`flag:"httpContentTypeNosniff" cfg:"httpContentTypeNosniff"`
+	HttpBrowserXssFilter		bool		`flag:"httpBrowserXssFilter" cfg:"httpBrowserXssFilter"`
+	HttpCustomBrowserXssValue	string 		`flag:"httpCustomBrowserXssValue" cfg:"httpCustomBrowserXssValue"`
+	HttpContentSecurityPolicy	string 		`flag:"httpContentSecurityPolicy" cfg:"httpContentSecurityPolicy"`
+	HttpPublicKey				string 		`flag:"httpPublicKey" cfg:"httpPublicKey"`
+	HttpReferrerPolicy			string 		`flag:"httpReferrerPolicy" cfg:"httpReferrerPolicy"`
+
 	// internal values that are set after config validation
 	redirectURL   *url.URL
 	proxyURLs     []*url.URL


### PR DESCRIPTION
I needed to be have XSS and nosniff headers set to help compliance scans not complain, so I followed through with the suggestion in https://github.com/bitly/oauth2_proxy/issues/384.  

Please let me know if you have any suggestions or things that I could do to help this get merged in.  We would love to be able to just use upstream for this.  

Thanks!
