### PR TITLE
optionally extract user from id_token in oidc provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Usage of oauth2_proxy:
   -tls-cert string: path to certificate file
   -tls-key string: path to private key file
   -upstream value: the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path
+  -username-claim string: Claim of the id_token that contains the user name when using oidc provider
   -validate-url string: Access token validation endpoint
   -version: print version string
 ```

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
+	flagSet.String("username-claim", "", "id_token claim containing the user name")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")

--- a/options.go
+++ b/options.go
@@ -72,6 +72,7 @@ type Options struct {
 	ProtectedResource string `flag:"resource" cfg:"resource"`
 	ValidateURL       string `flag:"validate-url" cfg:"validate_url"`
 	Scope             string `flag:"scope" cfg:"scope"`
+	UsernameClaim     string `flag:"username-claim" cfg:"username_claim"`
 	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt"`
 
 	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging"`
@@ -250,6 +251,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		ClientID:       o.ClientID,
 		ClientSecret:   o.ClientSecret,
 		ApprovalPrompt: o.ApprovalPrompt,
+		UsernameClaim:  o.UsernameClaim,
 	}
 	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
 	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -1,0 +1,134 @@
+package providers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	oidc "github.com/coreos/go-oidc"
+	"github.com/stretchr/testify/assert"
+)
+
+func newJsonReturningRedeemServer(body []byte) (*url.URL, *httptest.Server) {
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header()["Content-Type"] = []string{"application/json"}
+		rw.Write(body)
+	}))
+	u, _ := url.Parse(s.URL)
+	return u, s
+}
+
+var issuer string = "https://exmple.org/"
+
+type testVerifier struct {
+}
+
+func (t *testVerifier) VerifySignature(ctx context.Context, jwt string) ([]byte, error) {
+	parts := strings.Split(jwt, ".")
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
+	}
+	return payload, nil
+}
+
+func newOidcProvider() *OIDCProvider {
+	p := NewOIDCProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+			Scope:        ""})
+	p.Verifier = oidc.NewVerifier(issuer, &testVerifier{}, &oidc.Config{
+		SkipClientIDCheck: true,
+		SkipExpiryCheck:   true,
+	})
+	return p
+}
+
+// reusing redeemResponse from google_test
+
+func TestUserIsBlankByDefault(t *testing.T) {
+	p := newOidcProvider()
+	body, err := json.Marshal(redeemResponse{
+		AccessToken:  "a1234",
+		ExpiresIn:    10,
+		RefreshToken: "refresh12345",
+		IdToken:      base64.RawURLEncoding.EncodeToString([]byte(`{"typ": "jwt", "alg": "none"}`)) + "." + base64.RawURLEncoding.EncodeToString([]byte("{\"iss\": \""+issuer+"\", \"email\": \"jane.doe@example.org\", \"email_verified\":true}")) + ".",
+	})
+	assert.Equal(t, nil, err)
+	var server *httptest.Server
+	p.RedeemURL, server = newJsonReturningRedeemServer(body)
+	defer server.Close()
+
+	session, err := p.Redeem("http://redirect/", "code1234")
+	assert.Nil(t, err)
+	assert.NotNil(t, session)
+	assert.Equal(t, "", session.User)
+}
+
+func TestUserIsBlankIfConfiguredClaimIsMissing(t *testing.T) {
+	p := newOidcProvider()
+	p.ProviderData.UsernameClaim = "username"
+	body, err := json.Marshal(redeemResponse{
+		AccessToken:  "a1234",
+		ExpiresIn:    10,
+		RefreshToken: "refresh12345",
+		IdToken:      base64.RawURLEncoding.EncodeToString([]byte(`{"typ": "jwt", "alg": "none"}`)) + "." + base64.RawURLEncoding.EncodeToString([]byte("{\"iss\": \""+issuer+"\", \"email\": \"jane.doe@example.org\", \"email_verified\":true}")) + ".",
+	})
+	assert.Equal(t, nil, err)
+	var server *httptest.Server
+	p.RedeemURL, server = newJsonReturningRedeemServer(body)
+	defer server.Close()
+
+	session, err := p.Redeem("http://redirect/", "code1234")
+	assert.Nil(t, err)
+	assert.NotNil(t, session)
+	assert.Equal(t, "", session.User)
+}
+
+func TestUserIsSetFromConfiguredClaimIfPresent(t *testing.T) {
+	p := newOidcProvider()
+	p.ProviderData.UsernameClaim = "username"
+	body, err := json.Marshal(redeemResponse{
+		AccessToken:  "a1234",
+		ExpiresIn:    10,
+		RefreshToken: "refresh12345",
+		IdToken:      base64.RawURLEncoding.EncodeToString([]byte(`{"typ": "jwt", "alg": "none"}`)) + "." + base64.RawURLEncoding.EncodeToString([]byte("{\"iss\": \""+issuer+"\", \"email\": \"jane.doe@example.org\", \"email_verified\":true, \"username\": \"jd\"}")) + ".",
+	})
+	assert.Equal(t, nil, err)
+	var server *httptest.Server
+	p.RedeemURL, server = newJsonReturningRedeemServer(body)
+	defer server.Close()
+
+	session, err := p.Redeem("http://redirect/", "code1234")
+	assert.Nil(t, err)
+	assert.NotNil(t, session)
+	assert.Equal(t, "jd", session.User)
+}
+
+func TestAnErrorIsReturnedIfConfiguredUsernameClaimIsNotStringValued(t *testing.T) {
+	p := newOidcProvider()
+	p.ProviderData.UsernameClaim = "username"
+	body, err := json.Marshal(redeemResponse{
+		AccessToken:  "a1234",
+		ExpiresIn:    10,
+		RefreshToken: "refresh12345",
+		IdToken:      base64.RawURLEncoding.EncodeToString([]byte(`{"typ": "jwt", "alg": "none"}`)) + "." + base64.RawURLEncoding.EncodeToString([]byte("{\"iss\": \""+issuer+"\", \"email\": \"jane.doe@example.org\", \"email_verified\":true, \"username\": true}")) + ".",
+	})
+	assert.Equal(t, nil, err)
+	var server *httptest.Server
+	p.RedeemURL, server = newJsonReturningRedeemServer(body)
+	defer server.Close()
+
+	_, err = p.Redeem("http://redirect/", "code1234")
+	assert.NotNil(t, err)
+}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -15,6 +15,7 @@ type ProviderData struct {
 	ValidateURL       *url.URL
 	Scope             string
 	ApprovalPrompt    string
+	UsernameClaim     string
 }
 
 func (p *ProviderData) Data() *ProviderData { return p }


### PR DESCRIPTION
Current the oidc provider leaves the user blank. This PR adds an option that can be used to specify the id_token claim that shall be used to extract the userid - for keycloak this would be `preferred_username` for example.