### PR TITLE
optionally expose the access token in a response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Usage of oauth2_proxy:
   -resource string: The resource that is protected (Azure AD only)
   -scope string: OAuth scope specification
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
+  -set-xaccesstoken: set X-Access-Token response headers (useful in Nginx auth_request mode)
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
+	flagSet.Bool("set-xaccesstoken", false, "set X-Access-Token response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")

--- a/options.go
+++ b/options.go
@@ -60,6 +60,7 @@ type Options struct {
 	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
+	SetXAccessToken       bool     `flag:"set-xaccesstoken" cfg:"set_xaccesstoken"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 
 	// These options allow for other providers besides Google, with
@@ -105,6 +106,7 @@ func NewOptions() *Options {
 		CookieExpire:         time.Duration(168) * time.Hour,
 		CookieRefresh:        time.Duration(0),
 		SetXAuthRequest:      false,
+		SetXAccessToken:      false,
 		SkipAuthPreflight:    false,
 		PassBasicAuth:        true,
 		PassUserHeaders:      true,


### PR DESCRIPTION
This is similar to what #621 does to the id_token but exposes the access_token.

Use case is an nginx with `auth-request` that wants to make the access token available to the resource server "behind" the nginx.