### PR TITLE
Dropping = in the Nginx error_page setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ server {
 
   location / {
     auth_request /oauth2/auth;
-    error_page 401 = /oauth2/sign_in;
+    error_page 401 /oauth2/sign_in;
 
     # pass information via X-User and X-Email headers to backend,
     # requires running with --set-xauthrequest flag


### PR DESCRIPTION
With the = sign, the unauthenticated response is sent with the status code 200, not 401, which blurs the logs.
See also: https://serverfault.com/questions/295789/nginx-return-correct-headers-with-custom-error-documents