### PR TITLE
Add upstream-auth flag for sending id_token to upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.11-stretch
+
+WORKDIR /go
+
+RUN go get -d -v github.com/bitly/oauth2_proxy
+RUN go install -v github.com/bitly/oauth2_proxy
+
+CMD ["oauth2_proxy"]
+
+# Multi-stage build setup 
+
+# Stage 1 (to create a "build" image, ~850MB)
+FROM golang:1.11 AS builder
+RUN go version
+
+RUN go get -v github.com/bitly/oauth2_proxy
+
+WORKDIR /go/src/github.com/bitly/oauth2_proxy/
+COPY . /go/src/github.com/bitly/oauth2_proxy/
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o oauth2_proxy .
+
+# Stage 2
+
+# FROM alpine:3.7
+FROM docker.bulogics.com/tools:0.3.0
+# RUN apk --no-cache add ca-certificates
+
+WORKDIR /go/bin
+COPY --from=builder /go/src/github.com/bitly/oauth2_proxy/oauth2_proxy .
+
+ENTRYPOINT ["./oauth2_proxy"]

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
+	flagSet.String("upstream-auth", "", "What to pass in the Authorization header to the upstream. Only supported value: (id_token)")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 

--- a/options.go
+++ b/options.go
@@ -61,6 +61,7 @@ type Options struct {
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	UpstreamAuth          string   `flag:"upstream-auth" cfg:"upstream_auth"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.

--- a/providers/google.go
+++ b/providers/google.go
@@ -142,6 +142,7 @@ func (p *GoogleProvider) Redeem(redirectURL, code string) (s *SessionState, err 
 	}
 	s = &SessionState{
 		AccessToken:  jsonResponse.AccessToken,
+		IdToken:      jsonResponse.IdToken,
 		ExpiresOn:    time.Now().Add(time.Duration(jsonResponse.ExpiresIn) * time.Second).Truncate(time.Second),
 		RefreshToken: jsonResponse.RefreshToken,
 		Email:        email,

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -66,6 +66,7 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 	s = &SessionState{
 		AccessToken:  token.AccessToken,
 		RefreshToken: token.RefreshToken,
+		IdToken:      rawIDToken,
 		ExpiresOn:    token.Expiry,
 		Email:        claims.Email,
 	}


### PR DESCRIPTION
This is an alternate idea to the first part of #621 which would make a single option to declare what to send in the Authorization header to the upstream instead of several potentially incompatible `pass-foo` options. Currently just has `id_token` for kubernetes oidc auth with Google.