### PR TITLE
Add flag to skip upstream validation and proxying.

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,8 @@ func main() {
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
+	flagSet.Bool("auth-request-mode",false, "proxy used with NGINX auth_request, so no upstream needed")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {

--- a/options.go
+++ b/options.go
@@ -79,6 +79,8 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
+	AuthRequestMode bool `flag:"auth-request-mode" cfg:"auth_request_mode" env:"OAUTH2_PROXY_AUTH_REQUEST_MODE"`
+
 	// internal values that are set after config validation
 	redirectURL   *url.URL
 	proxyURLs     []*url.URL
@@ -167,15 +169,17 @@ func (o *Options) Validate() error {
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)
 
-	for _, u := range o.Upstreams {
-		upstreamURL, err := url.Parse(u)
-		if err != nil {
-			msgs = append(msgs, fmt.Sprintf("error parsing upstream: %s", err))
-		} else {
-			if upstreamURL.Path == "" {
-				upstreamURL.Path = "/"
+	if o.AuthRequestMode == false {
+		for _, u := range o.Upstreams {
+			upstreamURL, err := url.Parse(u)
+			if err != nil {
+				msgs = append(msgs, fmt.Sprintf("error parsing upstream: %s", err))
+			} else {
+				if upstreamURL.Path == "" {
+					upstreamURL.Path = "/"
+				}
+				o.proxyURLs = append(o.proxyURLs, upstreamURL)
 			}
-			o.proxyURLs = append(o.proxyURLs, upstreamURL)
 		}
 	}
 


### PR DESCRIPTION
I wanted to use oauth2_proxy along with auth_request module of NGINX for handling multiple sub-domains. In this case upstream is not a mandatory config since nginx is doing the proxying an our job is only to authenticate.

I did not find any way of avoiding upstream with current implementation and hence made this change.