### PR TITLE
Fix #403 by setting http.DefaultTransport correctly on -ssl-insecure-skip-verify=true

### DIFF
--- a/options.go
+++ b/options.go
@@ -131,7 +131,7 @@ func (o *Options) Validate() error {
 		insecureTransport := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
-		http.DefaultClient = &http.Client{Transport: insecureTransport}
+		http.DefaultTransport = insecureTransport
 	}
 
 	msgs := make([]string, 0)


### PR DESCRIPTION
In options.go make sure to set the default transport to insecure if the operator requested so via `--ssl-insecure-skip-verify=true` or `ssl_insecure_skip_verify = true`
    
This commit should fix #403 

