### PR TITLE
RD-4503: Handle missing username field in Gitlab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ _testmain.go
 
 # Editor swap/temp files
 .*.swp
+
+# Docker Compose environment variables
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM golang:alpine
 
 RUN apk add --no-cache git
 
-# Checkout CivicActions' latest google-auth-proxy code from Github
-RUN go get github.com/CivicActions/oauth2_proxy
+WORKDIR /go/src/oauth2_proxy
+COPY . .
+
+RUN go get -v && go install -v
 
 # Expose the ports we need and setup the ENTRYPOINT w/ the default argument
 # to be pass in.
 EXPOSE 80
-ENTRYPOINT [ "./bin/oauth2_proxy" ]
+ENTRYPOINT [ "/go/bin/oauth2_proxy" ]
 CMD [ "--upstream=http://upstream:80/", "--http-address=0.0.0.0:80" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine
+
+RUN apk add --no-cache git
+
+# Checkout CivicActions' latest google-auth-proxy code from Github
+RUN go get github.com/CivicActions/oauth2_proxy
+
+# Expose the ports we need and setup the ENTRYPOINT w/ the default argument
+# to be pass in.
+EXPOSE 80
+ENTRYPOINT [ "./bin/oauth2_proxy" ]
+CMD [ "--upstream=http://upstream:80/", "--http-address=0.0.0.0:80" ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -131,7 +131,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "gopkg.in/fsnotify/fsnotify.v1"
   packages = ["."]
   revision = "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6"
   version = "v1.2.11"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
   name = "google.golang.org/api"
 
 [[constraint]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "gopkg.in/fsnotify/fsnotify.v1"
   version = "~1.2.0"
 
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ If you are using GitHub enterprise, make sure you set the following to the appro
 
 Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](http://doc.gitlab.com/ce/integration/oauth_provider.html)
 
+The GitLab auth provider supports one additional parameters to restrict authentication to a specific group. Restricting by group is normally accompanied with `--email-domain=*`
+
+    -gitlab-group="": restrict logins to members of this group
+
 If you are using self-hosted GitLab, make sure you set the following to the appropriate URL:
 
     -login-url="<your gitlab url>/oauth/authorize"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you are using GitHub enterprise, make sure you set the following to the appro
 
 Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](http://doc.gitlab.com/ce/integration/oauth_provider.html)
 
-The GitLab auth provider supports one additional parameters to restrict authentication to a specific group. Restricting by group is normally accompanied with `--email-domain=*`
+The GitLab auth provider supports one additional parameter to restrict authentication to a specific group. Restricting by group is normally accompanied with `--email-domain=*`
 
     -gitlab-group="": restrict logins to members of this group
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '2'
+
+# Example oauth proxy set up using gitlab provider
+# Set the following variables in runtime or in .env file:
+# oauth2_url
+# oauth2_client_id
+# oauth2_client_secret
+# oauth2_cookie_secret
+
+services:
+  reverse-proxy:
+    image: traefik # The official Traefik docker image
+    command: --api --docker # Enables the web UI and tells Træfik to listen to docker
+    ports:
+      - "80:80"     # The HTTP port
+      - "8080:8080" # The Web UI (enabled by --api)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
+
+  whoami:
+    image: emilevauge/whoami # A container that exposes an API to show its IP address
+    labels:
+      - "traefik.frontend.rule=Host:whoami.docker.localhost"
+
+  auth:
+    build: .
+    command: ["--http-address=0.0.0.0:80", "--upstream=http://upstream:80/", "-provider=\"gitlab\"", "-redirect-url=\"https://auth.docker.localhost/oauth2/callback\"", "-login-url=\"https://${oauth2_url}/oauth/authorize\"", "-redeem-url=\"https://${oauth2_url}/oauth/token\"", "-validate-url=\"https://${oauth2_url}/api/v4/user\"", "-email-domain=*", "-cookie-secure=true", "-pass-access-token=true", "-pass-basic-auth=false", "-pass-host-header=true", "-pass-user-headers=true"]
+    environment:
+      OAUTH2_PROXY_CLIENT_ID: "${oauth2_client_id}"
+      OAUTH2_PROXY_CLIENT_SECRET: "${oauth2_client_secret}"
+      OAUTH2_PROXY_COOKIE_SECRET: "${oauth2_cookie_secret}"
+    links:
+    - "whoami:upstream"
+    labels:
+      - "traefik.frontend.rule=Host:auth.docker.localhost"
+

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
+	flagSet.String("gitlab-group", "", "restrict logins to members of this group")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/bitly/oauth2_proxy/cookie"
-	"github.com/bitly/oauth2_proxy/providers"
+	"github.com/CivicActions/oauth2_proxy/providers"
 	"github.com/mbland/hmacauth"
 )
 

--- a/options.go
+++ b/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
+	GitLabGroup              string   `flag:"gitlab-group" cfg:"gitlab_group"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
@@ -263,6 +264,8 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		p.Configure(o.AzureTenant)
 	case *providers.GitHubProvider:
 		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
+	case *providers.GitLabProvider:
+		p.SetGroup(o.GitLabGroup)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/options.go
+++ b/options.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitly/oauth2_proxy/providers"
+	"github.com/CivicActions/oauth2_proxy/providers"
 	oidc "github.com/coreos/go-oidc"
 	"github.com/mbland/hmacauth"
 )

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/bitly/oauth2_proxy/api"
-	"fmt"
-	"io/ioutil"
 	"encoding/json"
+	"fmt"
+	"github.com/bitly/oauth2_proxy/api"
+	"io/ioutil"
 )
 
 type GitLabProvider struct {
@@ -55,7 +55,7 @@ func (p *GitLabProvider) hasGroup(accessToken string) (bool, error) {
 		Group string `json:"name"`
 	}
 
-	endpoint := p.ValidateURL.Scheme + "://" + p.ValidateURL.Host + "/api/v3/groups?access_token="+accessToken
+	endpoint := p.ValidateURL.Scheme + "://" + p.ValidateURL.Host + "/api/v3/groups?access_token=" + accessToken
 	req, _ := http.NewRequest("GET", endpoint, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -76,7 +76,7 @@ func (p *GitLabProvider) hasGroup(accessToken string) (bool, error) {
 	}
 
 	for _, group := range groups {
-		if( p.Group == group.Group) {
+		if p.Group == group.Group {
 			// Found the group
 			return true, nil
 		}
@@ -85,7 +85,6 @@ func (p *GitLabProvider) hasGroup(accessToken string) (bool, error) {
 	log.Printf("Group %s not found in %s", p.Group, groups)
 	return false, nil
 }
-
 
 func (p *GitLabProvider) GetEmailAddress(s *SessionState) (string, error) {
 

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -10,6 +10,7 @@ import (
 
 type GitLabProvider struct {
 	*ProviderData
+	Group string
 }
 
 func NewGitLabProvider(p *ProviderData) *GitLabProvider {
@@ -39,6 +40,10 @@ func NewGitLabProvider(p *ProviderData) *GitLabProvider {
 		p.Scope = "read_user"
 	}
 	return &GitLabProvider{ProviderData: p}
+}
+
+func (p *GitLabProvider) SetGroup(group string) {
+	p.Group = group
 }
 
 func (p *GitLabProvider) GetEmailAddress(s *SessionState) (string, error) {

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -71,12 +71,14 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 
 func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 	chunks := strings.Split(v, " ")
-	if len(chunks) != 2 {
-		return nil, fmt.Errorf("could not decode session state: expected 2 chunks got %d", len(chunks))
-	}
 
 	email := strings.TrimPrefix(chunks[0], "email:")
-	user := strings.TrimPrefix(chunks[1], "user:")
+	user := ""
+	// for Admin users, Gitlab 10 only returns the email
+	if len(chunks) > 1 {
+		user = strings.TrimPrefix(chunks[1], "user:")
+	}
+
 	if user == "" {
 		user = strings.Split(email, "@")[0]
 	}

--- a/watcher.go
+++ b/watcher.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 )
 
 func WaitForReplacement(filename string, op fsnotify.Op,


### PR DESCRIPTION
For normal users, Gitlab has an email and username field in the session info.  Admin users only have email.