### PR TITLE
Redirect to uri even if --skip-provider-button

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -440,11 +440,19 @@ func TestSignInPageSkipProvider(t *testing.T) {
 		t.Fatal("Did not find pattern in body: " +
 			signInSkipProvider + "\nBody:\n" + body)
 	}
+
+	// State is a hex nonce, a colon (encoded as %3A), plus an escaped redirect path.
+	source_page_re := regexp.MustCompile("state=[0-9a-f]+%3A" + url.PathEscape(endpoint) + `[;"]`)
+	source_page_match := source_page_re.FindStringSubmatch(body)
+	if source_page_match == nil {
+		t.Fatal("Callback state should include redirect to original endpoint: " +
+			source_page_re.String() + "\nBody:\n" + body)
+	}
 }
 
 func TestSignInPageSkipProviderDirect(t *testing.T) {
 	sip_test := NewSignInPageTest(true)
-	const endpoint = "/sign_in"
+	const endpoint = "/oauth2/sign_in"
 
 	code, body := sip_test.GetEndpoint(endpoint)
 	assert.Equal(t, 302, code)
@@ -453,6 +461,14 @@ func TestSignInPageSkipProviderDirect(t *testing.T) {
 	if match == nil {
 		t.Fatal("Did not find pattern in body: " +
 			signInSkipProvider + "\nBody:\n" + body)
+	}
+
+	// State is a hex nonce, a colon (encoded as %3A), plus an escaped redirect path.
+	source_page_re := regexp.MustCompile(`state=[0-9a-f]+%3A%2F[;"]`)
+	source_page_match := source_page_re.FindStringSubmatch(body)
+	if source_page_match == nil {
+		t.Fatal("Callback state should include redirect to /: " +
+			source_page_re.String() + "\nBody:\n" + body)
 	}
 }
 


### PR DESCRIPTION
The normal behavior is that if a user is going to page
https://hostname/x but is not authenticated, they are sent to login and
then redirected back to https://hostname/x.

I discovered that if the flag --skip-provider-button is given, then
after login the user ends up at https://hostname/.

I believe this to be a bug. That behavior seems to happen because the
current URI is only extracted when redirecting to the sign-in page form,
not when the OAuth flow is started, so if that form is skipped, the
current URL is lost. Therefore, I made a change to extract the current
page to send into the OAuth flow.

This change fixes that bug and adds a test.